### PR TITLE
repoNames.json and gradle home

### DIFF
--- a/common-repo/src/functionalTest/groovy/com/apgsga/gradle/repo/plugin/BuildLogicFunctionalTest.groovy
+++ b/common-repo/src/functionalTest/groovy/com/apgsga/gradle/repo/plugin/BuildLogicFunctionalTest.groovy
@@ -26,7 +26,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 		when:
 		def result = GradleRunner.create()
 			.withProjectDir(testProjectDir)
-			.withArguments( 'init','--info', '--stacktrace')
+			.withArguments( "-Dgradle.user.home=${gradleHomeDir}", 'init','--info', '--stacktrace')
 			.withPluginClasspath()
 			.build()
 		then:
@@ -34,7 +34,6 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 		result.output.contains('maventestrepo')
 	}
 
-	
     def "Common Repo Plugin works explicit with Defaults"() {
         given:
         buildFile << """
@@ -52,7 +51,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
         when:
         def result = GradleRunner.create()
             .withProjectDir(testProjectDir)
-            .withArguments( 'init','--info', '--stacktrace')
+            .withArguments( "-Dgradle.user.home=${gradleHomeDir}", 'init','--info', '--stacktrace')
             .withPluginClasspath()
             .build()
         then:
@@ -87,7 +86,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 		when:
 		def result = GradleRunner.create()
 			.withProjectDir(testProjectDir)
-			.withArguments( 'init','--info', '--stacktrace')
+			.withArguments( "-Dgradle.user.home=${gradleHomeDir}", 'init','--info', '--stacktrace')
 			.withPluginClasspath()
 			.build()
 		then:
@@ -97,5 +96,3 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 		result.output.contains('otherdirectory')
 	}
 }
-
-

--- a/common-repo/src/main/java/com/apgsga/gradle/repo/extensions/RemoteRepo.java
+++ b/common-repo/src/main/java/com/apgsga/gradle/repo/extensions/RemoteRepo.java
@@ -25,7 +25,7 @@ public class RemoteRepo extends AbstractRepo {
 		super(project);
 
 		try {
-			String gradleHome = project.getGradle().getGradleHomeDir().getAbsolutePath();
+			String gradleHome = project.getGradle().getGradleUserHomeDir().getAbsolutePath();
 			FileSystemResourceLoader loader = new FileSystemResourceLoader();
 			String repoNamesJsonFilePath = "file://" + gradleHome + File.separator + REPO_NAMES_JSON_FILENAME;
 			Resource repoNamesJsonAsResource = loader.getResource(repoNamesJsonFilePath);

--- a/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/AppResourcesCopyTaskTests.groovy
+++ b/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/AppResourcesCopyTaskTests.groovy
@@ -29,7 +29,7 @@ class AppResourcesCopyTaskTests extends AbstractSpecification {
         when:
         def result = GradleRunner.create()
             .withProjectDir(testProjectDir)
-            .withArguments('copyAppResources','--info', '--stacktrace')
+            .withArguments("-Dgradle.user.home=${gradleHomeDir}", 'copyAppResources','--info', '--stacktrace')
             .withPluginClasspath()
             .build()
         then:
@@ -65,7 +65,7 @@ class AppResourcesCopyTaskTests extends AbstractSpecification {
 		when:
 		def result = GradleRunner.create()
 			.withProjectDir(testProjectDir)
-			.withArguments('copyAppResources','--info', '--stacktrace')
+			.withArguments("-Dgradle.user.home=${gradleHomeDir}", 'copyAppResources','--info', '--stacktrace')
 			.withPluginClasspath()
 			.build()
 		then:

--- a/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/BinariesCopyTaskTests.groovy
+++ b/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/BinariesCopyTaskTests.groovy
@@ -39,7 +39,7 @@ class BinariesCopyTaskTests extends AbstractSpecification {
         when:
         def result = GradleRunner.create()
             .withProjectDir(testProjectDir)
-            .withArguments('copyAppBinaries','--info', '--stacktrace')
+            .withArguments("-Dgradle.user.home=${gradleHomeDir}", 'copyAppBinaries','--info', '--stacktrace')
             .withPluginClasspath()
             .build()
         then:

--- a/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/CopyResourcesToBuildDirActionTests.groovy
+++ b/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/CopyResourcesToBuildDirActionTests.groovy
@@ -16,7 +16,7 @@ class CopyResourcesToBuildDirActionTests extends AbstractSpecification {
         when:
         def result = GradleRunner.create()
             .withProjectDir(testProjectDir)
-            .withArguments('copyCommonPackagingResources','--info', '--stacktrace')
+            .withArguments("-Dgradle.user.home=${gradleHomeDir}", 'copyCommonPackagingResources','--info', '--stacktrace')
             .withPluginClasspath()
             .build()
         then:

--- a/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/PropertyFileMergeTasksTests.groovy
+++ b/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/PropertyFileMergeTasksTests.groovy
@@ -26,7 +26,7 @@ class PropertyFileMergeTasksTests extends AbstractSpecification {
         when:
         def result = GradleRunner.create()
             .withProjectDir(testProjectDir)
-            .withArguments('mergeResourcePropertyFiles','--info', '--stacktrace')
+            .withArguments("-Dgradle.user.home=${gradleHomeDir}", 'mergeResourcePropertyFiles','--info', '--stacktrace')
             .withPluginClasspath()
             .build()
         then:
@@ -67,7 +67,7 @@ class PropertyFileMergeTasksTests extends AbstractSpecification {
 		when:
 		def result = GradleRunner.create()
 			.withProjectDir(testProjectDir)
-			.withArguments('mergeResourcePropertyFiles','--info', '--stacktrace')
+			.withArguments("-Dgradle.user.home=${gradleHomeDir}", 'mergeResourcePropertyFiles','--info', '--stacktrace')
 			.withPluginClasspath()
 			.build()
 		then:
@@ -110,7 +110,7 @@ class PropertyFileMergeTasksTests extends AbstractSpecification {
 		when:
 		def result = GradleRunner.create()
 			.withProjectDir(testProjectDir)
-			.withArguments('mergeAppConfigPropertyFiles','--info', '--stacktrace')
+			.withArguments("-Dgradle.user.home=${gradleHomeDir}", 'mergeAppConfigPropertyFiles','--info', '--stacktrace')
 			.withPluginClasspath()
 			.build()
 		then:
@@ -141,7 +141,7 @@ class PropertyFileMergeTasksTests extends AbstractSpecification {
 		when:
 		def result = GradleRunner.create()
 			.withProjectDir(testProjectDir)
-			.withArguments('mergeAppConfigPropertyFiles','--info', '--stacktrace')
+			.withArguments("-Dgradle.user.home=${gradleHomeDir}", 'mergeAppConfigPropertyFiles','--info', '--stacktrace')
 			.withPluginClasspath()
 			.build()
 		then:

--- a/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/TemplateDirCopyTaskTest.groovy
+++ b/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/TemplateDirCopyTaskTest.groovy
@@ -16,7 +16,7 @@ class TemplateDirCopyTaskTest extends AbstractSpecification {
         when:
         def result = GradleRunner.create()
             .withProjectDir(testProjectDir)
-            .withArguments('templateDirCopy','--info', '--stacktrace')
+            .withArguments("-Dgradle.user.home=${gradleHomeDir}", 'templateDirCopy','--info', '--stacktrace')
             .withPluginClasspath()
             .build()
         then:

--- a/common-test/build.gradle.kts
+++ b/common-test/build.gradle.kts
@@ -15,4 +15,5 @@ dependencies {
         exclude("","groovy-all")
     }
     compileOnly( "org.codehaus.groovy:groovy-all:2.4.17")
+    compile("org.springframework:spring-core:5.2.1.RELEASE")
 }

--- a/common-test/src/main/groovy/com/apgsga/gradle/test/utils/AbstractSpecification.groovy
+++ b/common-test/src/main/groovy/com/apgsga/gradle/test/utils/AbstractSpecification.groovy
@@ -1,13 +1,17 @@
 package com.apgsga.gradle.test.utils
 
+import org.springframework.core.io.ClassPathResource
 import spock.lang.Specification
 
 import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
 
 abstract class AbstractSpecification extends Specification {
 
     protected File testProjectDir
     protected File buildFile
+    protected String gradleHomeDir
 
     def setup() {
         println "Running setup"
@@ -29,9 +33,18 @@ abstract class AbstractSpecification extends Specification {
         buildDir.mkdirs()
         println "Project Dir : ${testProjectDir.absolutePath}"
         buildFile = new File(testProjectDir,"build.gradle" + buildTyp())
+        setupRepoNameJson()
     }
 
-    // may be overwritten with kts
+    def setupRepoNameJson() {
+        gradleHomeDir = "${System.getProperty('user.home')}${File.separator}.gradle${File.separator}"
+        if(!(new File(gradleHomeDir).exists())) {
+            Files.createDirectory(gradleHomeDir)
+        }
+        ClassPathResource cpr = new ClassPathResource("repoNames.json")
+        Files.copy(cpr.getInputStream(), Paths.get(gradleHomeDir + File.separator + "repoNames.json"), StandardCopyOption.REPLACE_EXISTING)
+    }
+// may be overwritten with kts
     protected def buildTyp() {
         ""
     }

--- a/common-test/src/main/resources/repoNames.json
+++ b/common-test/src/main/resources/repoNames.json
@@ -1,0 +1,16 @@
+{
+  "repos": [
+    {
+      "ZIP": "release-functionaltest"
+    },
+    {
+      "RPM": "rpm-functionaltest"
+    },
+    {
+      "MAVEN_SNAPSHOT": "snapshot-functionaltest"
+    },
+    {
+      "MAVEN_RELEASE": "release-functionaltest"
+    }
+  ]
+}

--- a/generic-publish/src/functionalTest/groovy/com/apgsga/gradle/publish/BuildLogicFunctionalTest.groovy
+++ b/generic-publish/src/functionalTest/groovy/com/apgsga/gradle/publish/BuildLogicFunctionalTest.groovy
@@ -30,7 +30,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
         when:
         def result = GradleRunner.create()
             .withProjectDir(testProjectDir)
-            .withArguments('apgGenericPublish','--info', '--stacktrace')
+            .withArguments("-Dgradle.user.home=${gradleHomeDir}", 'apgGenericPublish','--info', '--stacktrace')
             .withPluginClasspath()
             .build()
         then:
@@ -54,7 +54,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 		when:
 		def result = GradleRunner.create()
 			.withProjectDir(testProjectDir)
-			.withArguments('apgGenericPublish','--info', '--stacktrace')
+			.withArguments("-Dgradle.user.home=${gradleHomeDir}", 'apgGenericPublish','--info', '--stacktrace')
 			.withPluginClasspath()
 			.build()
 		then:
@@ -78,7 +78,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 		when:
 		def result = GradleRunner.create()
 			.withProjectDir(testProjectDir)
-			.withArguments('apgGenericPublish','--info', '--stacktrace')
+			.withArguments("-Dgradle.user.home=${gradleHomeDir}", 'apgGenericPublish','--info', '--stacktrace')
 			.withPluginClasspath()
 			.build()
 		then:
@@ -102,7 +102,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 		when:
 		def result = GradleRunner.create()
 			.withProjectDir(testProjectDir)
-			.withArguments('apgGenericPublish','--info', '--stacktrace')
+			.withArguments("-Dgradle.user.home=${gradleHomeDir}", 'apgGenericPublish','--info', '--stacktrace')
 			.withPluginClasspath()
 			.build()
 		then:
@@ -130,7 +130,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 		when:
 		def result = GradleRunner.create()
 			.withProjectDir(testProjectDir)
-			.withArguments('apgGenericPublish','--info', '--stacktrace')
+			.withArguments("-Dgradle.user.home=${gradleHomeDir}", 'apgGenericPublish','--info', '--stacktrace')
 			.withPluginClasspath()
 			.build()
 		then:

--- a/it21-gui-packager/src/functionalTest/groovy/com/apgsga/gradle/gui/pkg/tasks/ZipPackageTaskTests.groovy
+++ b/it21-gui-packager/src/functionalTest/groovy/com/apgsga/gradle/gui/pkg/tasks/ZipPackageTaskTests.groovy
@@ -32,7 +32,7 @@ class ZipPackageTaskTests extends AbstractSpecification  {
         when:
         def result = GradleRunner.create()
             .withProjectDir(testProjectDir)
-            .withArguments('zipPackageTask','--info', '--stacktrace')
+            .withArguments("-Dgradle.user.home=${gradleHomeDir}", 'zipPackageTask','--info', '--stacktrace')
             .withPluginClasspath()
             .build()
         then:

--- a/maven-publish/src/functionalTest/groovy/com/apg/gradle/plugins/BuildLogicFunctionalTest.groovy
+++ b/maven-publish/src/functionalTest/groovy/com/apg/gradle/plugins/BuildLogicFunctionalTest.groovy
@@ -32,7 +32,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
         when:
         def result = GradleRunner.create()
             .withProjectDir(testProjectDir)
-            .withArguments('clean','build', 'publish','--info', '--stacktrace')
+            .withArguments("-Dgradle.user.home=${gradleHomeDir}", 'clean','build', 'publish','--info', '--stacktrace')
             .withPluginClasspath()
             .build()
         then:
@@ -57,7 +57,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 		when:
 		def result = GradleRunner.create()
 			.withProjectDir(testProjectDir)
-			.withArguments('clean','build', 'publish','--info', '--stacktrace')
+			.withArguments("-Dgradle.user.home=${gradleHomeDir}", 'clean','build', 'publish','--info', '--stacktrace')
 			.withPluginClasspath()
 			.build()
 		then:
@@ -84,7 +84,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 		when:
 		def result = GradleRunner.create()
 			.withProjectDir(testProjectDir)
-			.withArguments('clean','build', 'publish','--info', '--stacktrace')
+			.withArguments("-Dgradle.user.home=${gradleHomeDir}", 'clean','build', 'publish','--info', '--stacktrace')
 			.withPluginClasspath()
 			.build()
 		then:
@@ -111,7 +111,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 		when:
 		def result = GradleRunner.create()
 			.withProjectDir(testProjectDir)
-			.withArguments('clean','build', 'publish','--info', '--stacktrace')
+			.withArguments("-Dgradle.user.home=${gradleHomeDir}", 'clean','build', 'publish','--info', '--stacktrace')
 			.withPluginClasspath()
 			.build()
 		then:

--- a/repo-config/src/functionalTest/groovy/com/apgsga/gradle/repo/config/plugin/BuildLogicFunctionalTest.groovy
+++ b/repo-config/src/functionalTest/groovy/com/apgsga/gradle/repo/config/plugin/BuildLogicFunctionalTest.groovy
@@ -40,7 +40,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 		when:
 			def result = GradleRunner.create()
 				.withProjectDir(testProjectDir)
-				.withArguments( 'listrepos')
+				.withArguments( "-Dgradle.user.home=${gradleHomeDir}", 'listrepos')
 				.withPluginClasspath()
 				.build()
 				
@@ -78,7 +78,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 		when:
 			def result = GradleRunner.create()
 				.withProjectDir(testProjectDir)
-				.withArguments( 'listrepos')
+				.withArguments( "-Dgradle.user.home=${gradleHomeDir}", 'listrepos')
 				.withPluginClasspath()
 				.build()
 				
@@ -112,7 +112,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 		when:
 			def result = GradleRunner.create()
 				.withProjectDir(testProjectDir)
-				.withArguments('clean','build','--info','--stacktrace')
+				.withArguments("-Dgradle.user.home=${gradleHomeDir}", 'clean','build','--info','--stacktrace')
 				.withPluginClasspath()
 				.build()
 				
@@ -139,7 +139,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 		when:
 			def result = GradleRunner.create()
 				.withProjectDir(testProjectDir)
-				.withArguments('init','--info', '--stacktrace')
+				.withArguments("-Dgradle.user.home=${gradleHomeDir}", 'init','--info', '--stacktrace')
 				.withPluginClasspath()
 				.build()
 				

--- a/rpm-service-packager/src/functionalTest/groovy/com/apgsga/gradle/rpm/pkg/tasks/BuildRpmTaskTests.groovy
+++ b/rpm-service-packager/src/functionalTest/groovy/com/apgsga/gradle/rpm/pkg/tasks/BuildRpmTaskTests.groovy
@@ -43,7 +43,7 @@ class BuildRpmTaskTests extends AbstractSpecification {
         when:
         def result = GradleRunner.create()
             .withProjectDir(testProjectDir)
-            .withArguments('buildRpm','--info', '--stacktrace')
+            .withArguments("-Dgradle.user.home=${gradleHomeDir}", 'buildRpm','--info', '--stacktrace')
             .withPluginClasspath()
             .build()
         then:

--- a/rpm-service-packager/src/functionalTest/groovy/com/apgsga/gradle/rpm/pkg/tasks/CopyResourcesToBuildDirActionTests.groovy
+++ b/rpm-service-packager/src/functionalTest/groovy/com/apgsga/gradle/rpm/pkg/tasks/CopyResourcesToBuildDirActionTests.groovy
@@ -27,7 +27,7 @@ class CopyResourcesToBuildDirActionTests extends AbstractSpecification {
         when:
         def result = GradleRunner.create()
             .withProjectDir(testProjectDir)
-            .withArguments('copyRpmPackagingResources','--info', '--stacktrace')
+            .withArguments("-Dgradle.user.home=${gradleHomeDir}", 'copyRpmPackagingResources','--info', '--stacktrace')
             .withPluginClasspath()
             .build()
         then:

--- a/rpm-service-packager/src/functionalTest/groovy/com/apgsga/gradle/rpm/pkg/tasks/RpmScriptsCopyTaskTests.groovy
+++ b/rpm-service-packager/src/functionalTest/groovy/com/apgsga/gradle/rpm/pkg/tasks/RpmScriptsCopyTaskTests.groovy
@@ -27,7 +27,7 @@ class RpmScriptsCopyTaskTests extends AbstractSpecification {
         when:
         def result = GradleRunner.create()
             .withProjectDir(testProjectDir)
-            .withArguments('copyRpmScripts','--info', '--stacktrace')
+            .withArguments("-Dgradle.user.home=${gradleHomeDir}", 'copyRpmScripts','--info', '--stacktrace')
             .withPluginClasspath()
             .build()
         then:

--- a/rpm-service-packager/src/functionalTest/groovy/com/apgsga/gradle/rpm/pkg/tasks/TemplateDirCopyTaskTest.groovy
+++ b/rpm-service-packager/src/functionalTest/groovy/com/apgsga/gradle/rpm/pkg/tasks/TemplateDirCopyTaskTest.groovy
@@ -24,7 +24,7 @@ class TemplateDirCopyTaskTest extends AbstractSpecification {
         when:
         def result = GradleRunner.create()
             .withProjectDir(testProjectDir)
-            .withArguments('templateDirCopy','--info', '--stacktrace')
+            .withArguments("-Dgradle.user.home=${gradleHomeDir}", 'templateDirCopy','--info', '--stacktrace')
             .withPluginClasspath()
             .build()
         then:


### PR DESCRIPTION
@chhex , @apgsga-stb : I'll merge this pull request immediately, I'm creating it for "documentation" only. If something should be done differently, I'll do the correction on master later ...

Basically, the repoNames.json has now been setup on jenkins.apgsga.ch within /var/jenkins/gradle/home. 

We don't need anymore to create a repoNames.json for our tests, it will be created dynamically.  The repoNames.json located within /var/jenkins/gradle/home is needed for normal build, like for example "testapp-service".