### PR TITLE
IT-34972 / user, password and repoUrl within JSON file

### DIFF
--- a/ssh-deployer/build.gradle
+++ b/ssh-deployer/build.gradle
@@ -1,0 +1,23 @@
+apply from: "${projectDir}/../gradle-common/common-plugin.gradle"
+apply from: "${projectDir}/../gradle-common/integration-test.gradle"
+apply from: "${projectDir}/../gradle-common/functional-test.gradle"
+
+group = 'com.apgsga.gradle'
+version = '0.1'
+description 'Provides standardized configurations for SSH deployment'
+
+sourceSets {
+    main {
+        java {
+            srcDirs = []
+        }
+        groovy {
+            srcDirs = ['src/main/groovy', 'src/main/java']
+        }
+    }
+}
+
+dependencies {
+    testCompile gradleTestKit()
+    testCompile project(':common-test')
+}

--- a/ssh-deployer/build/resources/main/META-INF.gradle-plugins/com.apgsga.gradle.sshdeployer.properties
+++ b/ssh-deployer/build/resources/main/META-INF.gradle-plugins/com.apgsga.gradle.sshdeployer.properties
@@ -1,0 +1,1 @@
+implementation-class=com.apgsga.gradle.sshdeployer.plugin.SshDeployerPlugin

--- a/ssh-deployer/src/functionalTest/groovy/com/apgsga/gradle/sshdeployer/SSHDeployTaskTest.groovy
+++ b/ssh-deployer/src/functionalTest/groovy/com/apgsga/gradle/sshdeployer/SSHDeployTaskTest.groovy
@@ -1,0 +1,33 @@
+package com.apgsga.gradle.sshdeployer
+
+import com.apgsga.gradle.test.utils.AbstractSpecification
+import org.gradle.testkit.runner.GradleRunner
+
+class SSHDeployTaskTest extends AbstractSpecification {
+
+    def "SSH Deployment task works"() {
+        given:
+            buildFile << """
+                    plugins {
+                        id 'com.apgsga.gradle.sshdeployer'
+                    }
+                    
+                    apgRepository {
+                        mavenLocal()
+                        mavenCentral()
+                    }
+                """
+        when:
+            def result = GradleRunner.create()
+                    .withProjectDir(testProjectDir)
+                    .withArguments( 'deployRpm')
+                    .withPluginClasspath()
+                    .build()
+
+        then:
+            println "Result output: ${result.output}"
+            // TODO JHE: correct test ... :)
+            result.output.contains('')
+    }
+
+}

--- a/ssh-deployer/src/main/groovy/com/apgsga/gradle/sshdeployer/tasks/DeployRpm.groovy
+++ b/ssh-deployer/src/main/groovy/com/apgsga/gradle/sshdeployer/tasks/DeployRpm.groovy
@@ -1,0 +1,14 @@
+package com.apgsga.gradle.sshdeployer.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+class DeployRpm extends DefaultTask {
+
+    @TaskAction
+    def taskAction() {
+
+        println "Task action from DeployRpm task !!!!!!!!!!!!!!!!!!!!!"
+
+    }
+}

--- a/ssh-deployer/src/main/java/com/apgsga/gradle/sshdeployer/plugin/SshDeployerPlugin.java
+++ b/ssh-deployer/src/main/java/com/apgsga/gradle/sshdeployer/plugin/SshDeployerPlugin.java
@@ -1,0 +1,20 @@
+package com.apgsga.gradle.sshdeployer.plugin;
+
+import com.apgsga.gradle.sshdeployer.tasks.DeployRpm;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.PluginContainer;
+import org.gradle.api.tasks.TaskContainer;
+
+public class SshDeployerPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+
+        final PluginContainer plugins = project.getPlugins();
+        plugins.apply("org.hidetake.ssh");
+
+        TaskContainer tasks = project.getTasks();
+        tasks.register("deployRpm", DeployRpm.class);
+    }
+}

--- a/ssh-deployer/src/main/resources/META-INF.gradle-plugins/com.apgsga.gradle.sshdeployer.properties
+++ b/ssh-deployer/src/main/resources/META-INF.gradle-plugins/com.apgsga.gradle.sshdeployer.properties
@@ -1,0 +1,1 @@
+implementation-class=com.apgsga.gradle.sshdeployer.plugin.SshDeployerPlugin


### PR DESCRIPTION
Reading info from repoNames.json.
I'll also integrate the modifications suggested by @chhex within https://github.com/apgsga-it/apg-gradle-plugins/pull/7 ..... but this can already been reviewd.

One question ... : I find repoNames.json not a very good name anymore ... What do you think? What about "apgGradlePluginConfig.json" ?