### PR TITLE
IT-35042 / Externalize Service List into Json File in Gradlehome

### DIFF
--- a/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/AppResourcesCopyTaskTests.groovy
+++ b/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/AppResourcesCopyTaskTests.groovy
@@ -52,7 +52,6 @@ class AppResourcesCopyTaskTests extends AbstractSpecification {
             }
 		 apgPackage {
 			serviceName ="testapp"
-			supportedServices = ["testapp"]
             installTarget = "CHTX211"
 			mainProgramName  = "com.apgsga.test.SomeMain"
          }

--- a/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/BinariesCopyTaskTests.groovy
+++ b/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/BinariesCopyTaskTests.groovy
@@ -29,7 +29,6 @@ class BinariesCopyTaskTests extends AbstractSpecification {
 		// The guava dependency is only for testing purposes, consider to be likely found in mavenCentral()
         apgPackage {
 			serviceName ="testapp"
-			supportedServices = ["testapp"]
 		    dependencies = ["com.google.guava:guava:+"]
             installTarget = "CHTX211"
 			mainProgramName  = "com.apgsga.test.SomeMain"

--- a/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/extension/ApgCommonPackageExtension.java
+++ b/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/extension/ApgCommonPackageExtension.java
@@ -1,11 +1,9 @@
 package com.apgsga.gradle.common.pkg.extension;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.gradle.api.Project;
 
-import com.google.common.collect.Lists;
+import java.util.Arrays;
+import java.util.List;
 
 public class ApgCommonPackageExtension {
 	
@@ -30,10 +28,7 @@ public class ApgCommonPackageExtension {
 	private static final String TARGET_DEFAULT = "CHEI212";
 	private static final String MAIN_PRG_DEFAULT = "com.apgsga.it21.ui.webapp.Webapp";
 	private static final String SERVICE_NAME_DEFAULT = "jadas";
-	// TODO (che, 25.9) : probably not the perfect places 
-	private static final List<String> SUPPORTED_SERVICE_NAMES_DEFAULT = Lists.newArrayList("jadas", "digiflex","vkjadas", "interjadas", "interweb"); 
-	
-	
+
 	private String serviceName =  SERVICE_NAME_DEFAULT; 
 	private String mainProgramName = MAIN_PRG_DEFAULT; 
 	private String installTarget = TARGET_DEFAULT; 
@@ -49,8 +44,8 @@ public class ApgCommonPackageExtension {
 	private String javaDir = JAVADIR_DEFAULT; 
 	private String javaDist = JAVADIST_DEFAULT; 
 	// TODO (che, 25.9) : retrieve baseUrl from common-repo Plugin 
-	private String distRepoUrl = REPO_BASE_URL_DEFAULT + JDK_DIST_REPO_NAME_DEFAULT; 
-	private List<String> supportedServices = SUPPORTED_SERVICE_NAMES_DEFAULT; 
+	private String distRepoUrl = REPO_BASE_URL_DEFAULT + JDK_DIST_REPO_NAME_DEFAULT;
+	private List<String> supportedServices;
 	private String version = VERSION_DEFAULT; 
 	private String releaseNr = RELEASENR_DEFAULT; 
 	private String opsUserGroup = APG_OPSDEFAULT; 
@@ -61,6 +56,9 @@ public class ApgCommonPackageExtension {
 		super();
 		this.project = project;
 	}
+
+	public List<String> getSupportedServices() { return supportedServices; }
+	public void setSupportedServices(List<String> supportedServices) { this.supportedServices = supportedServices; }
 	public String getServiceName() {
 		return serviceName;
 	}
@@ -152,14 +150,7 @@ public class ApgCommonPackageExtension {
 	public void setDistRepoUrl(String distRepoUrl) {
 		this.distRepoUrl = distRepoUrl;
 	}
-	
-	public List<String> getSupportedServices() {
-		return supportedServices;
-	}
-	public void setSupportedServices(List<String> supportedServices) {
-		this.supportedServices = supportedServices;
-	}
-	
+
 	public String getVersion() {
 		return version;
 	}
@@ -211,7 +202,7 @@ public class ApgCommonPackageExtension {
 	}
 	
 	public String getPortNr() {
-		return PortnrConvention.calculate(getSupportedServices(), getInstallTarget(), getServiceName()); 
+		return PortnrConvention.calculate(supportedServices, getInstallTarget(), getServiceName());
 	}
 	
 	public String getEcmTargetSystemInd() {
@@ -226,6 +217,7 @@ public class ApgCommonPackageExtension {
 	public String getArchiveName() {
 		return getTargetServiceName() + "-" + getVersion() + "-" + getReleaseNr()+ ".noarch.rpm"; 
 	}
+
 	@Override
 	public String toString() {
 		return "ApgRpmPackageExtension [serviceName=" + serviceName + ", mainProgramName=" + mainProgramName
@@ -238,8 +230,4 @@ public class ApgCommonPackageExtension {
 				+ ", version=" + version + ", releaseNr=" + releaseNr + ", opsUserGroup=" + opsUserGroup
 				+ ", servicePropertiesDir=" + servicePropertiesDir + "]";
 	}
-	
-	
-	
-
 }

--- a/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/extension/ApgCommonPackageExtension.java
+++ b/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/extension/ApgCommonPackageExtension.java
@@ -52,13 +52,12 @@ public class ApgCommonPackageExtension {
 	private String servicePropertiesDir = SERVICE_PROPERTIES_DIR_DEFAULT; 
 	private final Project project; 
 	
-	public ApgCommonPackageExtension(Project project) {
+	public ApgCommonPackageExtension(Project project, List<String> supportedServices) {
 		super();
 		this.project = project;
+		this.supportedServices = supportedServices;
 	}
 
-	public List<String> getSupportedServices() { return supportedServices; }
-	protected void setSupportedServices(List<String> supportedServices) { this.supportedServices = supportedServices; }
 	public String getServiceName() {
 		return serviceName;
 	}

--- a/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/extension/ApgCommonPackageExtension.java
+++ b/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/extension/ApgCommonPackageExtension.java
@@ -58,7 +58,7 @@ public class ApgCommonPackageExtension {
 	}
 
 	public List<String> getSupportedServices() { return supportedServices; }
-	public void setSupportedServices(List<String> supportedServices) { this.supportedServices = supportedServices; }
+	protected void setSupportedServices(List<String> supportedServices) { this.supportedServices = supportedServices; }
 	public String getServiceName() {
 		return serviceName;
 	}

--- a/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/plugin/ApgCommonPackagePlugin.java
+++ b/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/plugin/ApgCommonPackagePlugin.java
@@ -19,8 +19,6 @@ import org.springframework.util.Assert;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class ApgCommonPackagePlugin implements Plugin<Project> {
 
@@ -37,7 +35,7 @@ public class ApgCommonPackagePlugin implements Plugin<Project> {
 		final PluginContainer plugins = project.getPlugins();
 		plugins.apply(ApgRepoConfigPlugin.class);
 		ApgCommonPackageExtension apgPackage = ext.create("apgPackage", ApgCommonPackageExtension.class, project);
-		apgPackage.setSupportedServices(Stream.of(loadSupportedServices().supportedServices.split(",")).collect(Collectors.toList()));
+		apgPackage.setSupportedServices(loadSupportedServices().supportedServices);
 		TaskContainer tasks = project.getTasks();
 		TaskProvider<Copy> copyPackagingResourcesTask = tasks.register("copyCommonPackagingResources", Copy.class,
 				new CopyResourcesToBuildDirAction(project));

--- a/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/plugin/ApgCommonPackagePlugin.java
+++ b/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/plugin/ApgCommonPackagePlugin.java
@@ -1,5 +1,10 @@
 package com.apgsga.gradle.common.pkg.plugin;
 
+import com.apgsga.gradle.common.pkg.actions.CopyResourcesToBuildDirAction;
+import com.apgsga.gradle.common.pkg.extension.ApgCommonPackageExtension;
+import com.apgsga.gradle.common.pkg.task.*;
+import com.apgsga.gradle.repo.config.plugin.ApgRepoConfigPlugin;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
@@ -8,27 +13,31 @@ import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
+import org.springframework.core.io.FileSystemResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.util.Assert;
 
-import com.apgsga.gradle.common.pkg.actions.CopyResourcesToBuildDirAction;
-import com.apgsga.gradle.common.pkg.extension.ApgCommonPackageExtension;
-import com.apgsga.gradle.common.pkg.task.AppConfigFileMergerTask;
-import com.apgsga.gradle.common.pkg.task.AppResourcesCopyTask;
-import com.apgsga.gradle.common.pkg.task.BinariesCopyTask;
-import com.apgsga.gradle.common.pkg.task.ResourceFileMergerTask;
-import com.apgsga.gradle.common.pkg.task.TemplateDirCopyTask;
-import com.apgsga.gradle.repo.config.plugin.ApgRepoConfigPlugin;
+import java.io.File;
+import java.io.IOException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ApgCommonPackagePlugin implements Plugin<Project> {
+
+	private static final String INSTALLABLE_SERVICES_JSON_FILENAME = "supportedServices.json";
+
+	private Project project;
 
 	@SuppressWarnings("unused")
 	@Override
 	public void apply(Project project) {
-
+		this.project = project;
 		final ExtensionContainer ext = project.getExtensions();
 		final Logger logger = project.getLogger();
 		final PluginContainer plugins = project.getPlugins();
 		plugins.apply(ApgRepoConfigPlugin.class);
-		ext.create("apgPackage", ApgCommonPackageExtension.class, project);
+		ApgCommonPackageExtension apgPackage = ext.create("apgPackage", ApgCommonPackageExtension.class, project);
+		apgPackage.setSupportedServices(Stream.of(loadSupportedServices().supportedServices.split(",")).collect(Collectors.toList()));
 		TaskContainer tasks = project.getTasks();
 		TaskProvider<Copy> copyPackagingResourcesTask = tasks.register("copyCommonPackagingResources", Copy.class,
 				new CopyResourcesToBuildDirAction(project));
@@ -46,6 +55,25 @@ public class ApgCommonPackagePlugin implements Plugin<Project> {
 		TaskProvider<BinariesCopyTask> binariesCopyTask = tasks.register("copyAppBinaries", BinariesCopyTask.class);
 		binariesCopyTask.configure(task -> task.dependsOn(appResourcesCopyAndExpandTask));
 
+	}
+
+	private SupportedServicesBean loadSupportedServices() {
+		SupportedServicesBean ssb = null;
+		try {
+			ssb = new ObjectMapper().readerFor(SupportedServicesBean.class).readValue(getSupportedServicesAsResource().getFile());
+		} catch (IOException e) {
+			throw new RuntimeException("Problem while deserializing " + INSTALLABLE_SERVICES_JSON_FILENAME + ". Original   exception was: " + e.getMessage());
+		}
+		return ssb;
+	}
+
+	private Resource getSupportedServicesAsResource() {
+		String gradleHome = project.getGradle().getGradleUserHomeDir().getAbsolutePath();
+		FileSystemResourceLoader loader = new FileSystemResourceLoader();
+		String installableServicesJsonFilePath = "file://" + gradleHome + File.separator + INSTALLABLE_SERVICES_JSON_FILENAME;
+		Resource installableServicesJsonAsResource = loader.getResource(installableServicesJsonFilePath);
+		Assert.isTrue(installableServicesJsonAsResource.exists(), "installableServices.json file not found! installableServicesJsonFilePath = " + installableServicesJsonFilePath);
+		return installableServicesJsonAsResource;
 	}
 
 }

--- a/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/plugin/ApgCommonPackagePlugin.java
+++ b/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/plugin/ApgCommonPackagePlugin.java
@@ -34,8 +34,7 @@ public class ApgCommonPackagePlugin implements Plugin<Project> {
 		final Logger logger = project.getLogger();
 		final PluginContainer plugins = project.getPlugins();
 		plugins.apply(ApgRepoConfigPlugin.class);
-		ApgCommonPackageExtension apgPackage = ext.create("apgPackage", ApgCommonPackageExtension.class, project);
-		apgPackage.setSupportedServices(loadSupportedServices().supportedServices);
+		ext.create("apgPackage", ApgCommonPackageExtension.class, project, loadSupportedServices().supportedServices);
 		TaskContainer tasks = project.getTasks();
 		TaskProvider<Copy> copyPackagingResourcesTask = tasks.register("copyCommonPackagingResources", Copy.class,
 				new CopyResourcesToBuildDirAction(project));

--- a/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/plugin/SupportedServicesBean.java
+++ b/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/plugin/SupportedServicesBean.java
@@ -2,8 +2,10 @@ package com.apgsga.gradle.common.pkg.plugin;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 public class SupportedServicesBean {
 
     @JsonProperty
-    public String supportedServices;
+    public List<String> supportedServices;
 }

--- a/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/plugin/SupportedServicesBean.java
+++ b/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/plugin/SupportedServicesBean.java
@@ -1,0 +1,9 @@
+package com.apgsga.gradle.common.pkg.plugin;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SupportedServicesBean {
+
+    @JsonProperty
+    public String supportedServices;
+}

--- a/common-test/src/main/groovy/com/apgsga/gradle/test/utils/AbstractSpecification.groovy
+++ b/common-test/src/main/groovy/com/apgsga/gradle/test/utils/AbstractSpecification.groovy
@@ -16,7 +16,9 @@ abstract class AbstractSpecification extends Specification {
         deletePreviousTestFolders()
         setupTestProjectDir()
         createBuildFile()
+        createGradleHomeDir()
         setupRepoNameJson()
+        setupSupportedServicesJson()
     }
 
     private def createBuildFile() {
@@ -55,12 +57,28 @@ abstract class AbstractSpecification extends Specification {
         println "Project Dir : ${testProjectDir.absolutePath}"
     }
 
-    private def setupRepoNameJson() {
+    def createGradleHomeDir() {
         gradleHomeDirPath = "${testProjectDir}${File.separator}.gradle${File.separator}"
         File gradleHomeDir = new File(gradleHomeDirPath)
         gradleHomeDir.mkdirs()
         println "Gradle Home directory for tests: ${gradleHomeDir.absolutePath}"
-        File repoNamesJson = new File(gradleHomeDir, "repoNames.json")
+    }
+
+    def setupSupportedServicesJson() {
+        File installableServicesJson = new File(gradleHomeDirPath, "supportedServices.json")
+        initSupportedServicesJsonContent(installableServicesJson)
+    }
+
+    def initSupportedServicesJsonContent(File file) {
+        file << """
+            {
+                "supportedServices": "jadas,digiflex,vkjadas,interjadas,interweb,testapp"
+            }
+        """
+    }
+
+    private def setupRepoNameJson() {
+        File repoNamesJson = new File(gradleHomeDirPath, "repoNames.json")
         initTepoNamesJsonContent(repoNamesJson)
     }
 

--- a/common-test/src/main/groovy/com/apgsga/gradle/test/utils/AbstractSpecification.groovy
+++ b/common-test/src/main/groovy/com/apgsga/gradle/test/utils/AbstractSpecification.groovy
@@ -72,7 +72,7 @@ abstract class AbstractSpecification extends Specification {
     def initSupportedServicesJsonContent(File file) {
         file << """
             {
-                "supportedServices": "jadas,digiflex,vkjadas,interjadas,interweb,testapp"
+                "supportedServices": ["jadas","digiflex","vkjadas","interjadas","interweb","testapp"]
             }
         """
     }

--- a/rpm-service-packager/src/functionalTest/groovy/com/apgsga/gradle/rpm/pkg/tasks/BuildRpmTaskTests.groovy
+++ b/rpm-service-packager/src/functionalTest/groovy/com/apgsga/gradle/rpm/pkg/tasks/BuildRpmTaskTests.groovy
@@ -31,7 +31,6 @@ class BuildRpmTaskTests extends AbstractSpecification {
 		// The guava dependency is only for testing purposes, consider to be likely found in mavenCentral()
         apgPackage {
 			serviceName ="testapp"
-			supportedServices = ["testapp"]
 		    dependencies = ["com.google.guava:guava:+"]
             installTarget = "CHTX211"
 			mainProgramName  = "com.apgsga.test.SomeMain"

--- a/zip-service-packager/src/functionalTest/groovy/com/apgsga/gradle/zip/pkg/tasks/TarGzipTaskTests.groovy
+++ b/zip-service-packager/src/functionalTest/groovy/com/apgsga/gradle/zip/pkg/tasks/TarGzipTaskTests.groovy
@@ -24,7 +24,6 @@ class TarGzipTaskTests extends AbstractSpecification {
 		// The guava dependency is only for testing purposes, consider to be likely found in mavenCentral()
         apgPackage {
 			serviceName ="testapp"
-			supportedServices = ["testapp"]
 		    dependencies = ["com.google.guava:guava:+"]
             installTarget = "CHTX211"
 			mainProgramName  = "com.apgsga.test.SomeMain"


### PR DESCRIPTION
List of supported services is retrieved from an external JSON file called supportedServices.json.

It has been made based on the same logic as for repoNames.json.