### PR TITLE
IT-34790 / Getting remote Repo URL from ApgCommonRepoPlugin

### DIFF
--- a/common-repo/src/functionalTest/groovy/com/apgsga/gradle/repo/plugin/BuildLogicFunctionalTest.groovy
+++ b/common-repo/src/functionalTest/groovy/com/apgsga/gradle/repo/plugin/BuildLogicFunctionalTest.groovy
@@ -45,7 +45,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 			result.output.contains('repoName=snapshot-functionaltest')
 			result.output.contains('repoName=local')
 			result.output.contains('repoName=maven')
-			result.output.contains('repoName=java-dist')
+			result.output.contains('repoName=apgPlatformDependencies-test')
 	}
 
     def "Common Repo Plugin works explicit with Defaults"() {
@@ -73,7 +73,7 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 			result.output.contains('repoName=snapshot-functionaltest')
 			result.output.contains('repoName=local')
 			result.output.contains('repoName=maven')
-			result.output.contains('repoName=java-dist')
+			result.output.contains('repoName=apgPlatformDependencies-test')
     }
 	
 	
@@ -107,6 +107,6 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 			!result.output.contains('repoName=local')
 			result.output.contains('repoName=thisIsMyLocalRepo')
 			result.output.contains('repoName=maven')
-			result.output.contains('repoName=java-dist')
+			result.output.contains('repoName=apgPlatformDependencies-test')
 	}
 }

--- a/common-repo/src/main/java/com/apgsga/gradle/repo/plugin/ApgCommonRepoPlugin.java
+++ b/common-repo/src/main/java/com/apgsga/gradle/repo/plugin/ApgCommonRepoPlugin.java
@@ -22,8 +22,6 @@ public class ApgCommonRepoPlugin implements Plugin<Project> {
 
 	public static final String COMMMON_REPO_EXTENSION_NAME = "apgRepos";
 
-	public static String DEFAULT_REMOTE_REPO_URL = "";
-
 	private static final String REPO_NAMES_JSON_FILENAME = "repoNames.json";
 
 	private Project project;
@@ -35,10 +33,9 @@ public class ApgCommonRepoPlugin implements Plugin<Project> {
 		ReposImpl reposImpl = ext.create(COMMMON_REPO_EXTENSION_NAME, ReposImpl.class, project);
 
 		RepoNamesBean repoNames = loadRepoNames();
-		DEFAULT_REMOTE_REPO_URL = repoNames.repoBaseUrl;
 		// TODO (jhe,stb, che, 18.12) : As discussed the enum's should be serializable via Jackson
 		repoNames.repos.forEach(r -> r.keySet().forEach(key -> {
-			String remoteRepoBaseUrl = key.equals(RepoType.LOCAL) ? project.getRepositories().mavenLocal().getUrl().getPath() : DEFAULT_REMOTE_REPO_URL;
+			String remoteRepoBaseUrl = key.equals(RepoType.LOCAL) ? project.getRepositories().mavenLocal().getUrl().getPath() : repoNames.repoBaseUrl;
 			reposImpl.getRepositories().put(key, new ApgRepo(remoteRepoBaseUrl, r.get(key), repoNames.repoUserName, repoNames.repoUserPwd));
 		}));
 	}

--- a/common-repo/src/main/java/com/apgsga/gradle/repo/plugin/ApgCommonRepoPlugin.java
+++ b/common-repo/src/main/java/com/apgsga/gradle/repo/plugin/ApgCommonRepoPlugin.java
@@ -18,7 +18,11 @@ import java.io.IOException;
 @NonNullApi
 public class ApgCommonRepoPlugin implements Plugin<Project> {
 
+	public static final String PLUGIN_ID = "com.apgsga.common.repo";
+
 	public static final String COMMMON_REPO_EXTENSION_NAME = "apgRepos";
+
+	public static String DEFAULT_REMOTE_REPO_URL = "";
 
 	private static final String REPO_NAMES_JSON_FILENAME = "repoNames.json";
 
@@ -31,9 +35,10 @@ public class ApgCommonRepoPlugin implements Plugin<Project> {
 		ReposImpl reposImpl = ext.create(COMMMON_REPO_EXTENSION_NAME, ReposImpl.class, project);
 
 		RepoNamesBean repoNames = loadRepoNames();
+		DEFAULT_REMOTE_REPO_URL = repoNames.repoBaseUrl;
 		// TODO (jhe,stb, che, 18.12) : As discussed the enum's should be serializable via Jackson
 		repoNames.repos.forEach(r -> r.keySet().forEach(key -> {
-			String remoteRepoBaseUrl = key.equals(RepoType.LOCAL) ? project.getRepositories().mavenLocal().getUrl().getPath() : repoNames.repoBaseUrl;
+			String remoteRepoBaseUrl = key.equals(RepoType.LOCAL) ? project.getRepositories().mavenLocal().getUrl().getPath() : DEFAULT_REMOTE_REPO_URL;
 			reposImpl.getRepositories().put(key, new ApgRepo(remoteRepoBaseUrl, r.get(key), repoNames.repoUserName, repoNames.repoUserPwd));
 		}));
 	}

--- a/common-repo/src/test/java/com/apgsga/gradle/repo/util/DeserializeRepoNamesTest.java
+++ b/common-repo/src/test/java/com/apgsga/gradle/repo/util/DeserializeRepoNamesTest.java
@@ -21,7 +21,7 @@ public class DeserializeRepoNamesTest {
     public void testReadRepoNamesContent() throws IOException {
         Resource repoNamesTest = new ClassPathResource("repoNamesTest.json");
         RepoNamesBean r = new ObjectMapper().readerFor(RepoNamesBean.class).readValue(repoNamesTest.getInputStream());
-        Assert.assertEquals("Not all repos correctly loaded", 4, r.repos.size());
+        Assert.assertEquals("Not all repos correctly loaded", 5, r.repos.size());
         Assert.assertEquals("user name not correctly loaded", "gradledev-tests-user", r.repoUserName);
         Assert.assertEquals("user password not correctly loaded", "gradledev-tests-user", r.repoUserPwd);
         Assert.assertEquals("repo URL not correctly loaded", "https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga", r.repoBaseUrl);
@@ -42,6 +42,9 @@ public class DeserializeRepoNamesTest {
                     break;
                 case MAVEN_RELEASE:
                     Assert.assertEquals(rt.asString() + "repo not correctly loaded", "release-functionaltest", m.values().toArray()[0]);
+                    break;
+                case JAVA_DIST:
+                    Assert.assertEquals(rt.asString() + "repo not correctly loaded", "apgPlatformDependencies-test", m.values().toArray()[0]);
                     break;
                 default:
                     Assert.fail(rt.asString() + " has been loaded, but was not in repoNamesTest.json");

--- a/common-repo/src/test/resources/repoNamesTest.json
+++ b/common-repo/src/test/resources/repoNamesTest.json
@@ -11,6 +11,9 @@
     },
     {
       "MAVEN_RELEASE": "release-functionaltest"
+    },
+    {
+      "JAVA_DIST": "apgPlatformDependencies-test"
     }
   ],
   "repoUserName": "gradledev-tests-user",

--- a/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/ConfigFromCommonRepoTest.groovy
+++ b/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/ConfigFromCommonRepoTest.groovy
@@ -21,6 +21,6 @@ class ConfigFromCommonRepoTest extends AbstractSpecification {
         then:
         // TODO JHE: well, not a very good test, but it at least ensure the default URL from common-repo has correctly been retrieved.
         println result.output
-        result.output.contains('distRepoUrl=https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga/apgPlatformDependencies')
+        result.output.contains("distRepoUrl='https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga/apgPlatformDependencies-test'")
     }
 }

--- a/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/ConfigFromCommonRepoTest.groovy
+++ b/common-service-packager/src/functionalTest/groovy/com/apgsga/gradle/common/pkg/task/ConfigFromCommonRepoTest.groovy
@@ -1,0 +1,26 @@
+package com.apgsga.gradle.common.pkg.task
+
+import com.apgsga.gradle.test.utils.AbstractSpecification
+import spock.lang.Shared
+
+import static groovy.io.FileType.FILES
+
+class ConfigFromCommonRepoTest extends AbstractSpecification {
+
+    def "repoBaseUrl config works"() {
+        given:
+        buildFile << """
+                plugins {
+                    id 'com.apgsga.common.package'
+                }
+                println apgPackage.toString()
+            """
+
+        when:
+        def result = gradleRunnerFactory(['copyCommonPackagingResources']).build()
+        then:
+        // TODO JHE: well, not a very good test, but it at least ensure the default URL from common-repo has correctly been retrieved.
+        println result.output
+        result.output.contains('distRepoUrl=https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga/apgPlatformDependencies')
+    }
+}

--- a/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/extension/ApgCommonPackageExtension.java
+++ b/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/extension/ApgCommonPackageExtension.java
@@ -8,7 +8,8 @@ import java.util.Arrays;
 import java.util.List;
 
 public class ApgCommonPackageExtension {
-	
+
+    public static final String CONFIGURATION_NAME_DEFAULT = "serviceRuntime";
 	private static final String SERVICE_PROPERTIES_DIR_DEFAULT = "resources";
 	private static final String APG_OPSDEFAULT = "apg_ops";
 	private static final String RELEASENR_DEFAULT = "1";
@@ -30,6 +31,7 @@ public class ApgCommonPackageExtension {
 	private static final String MAIN_PRG_DEFAULT = "com.apgsga.it21.ui.webapp.Webapp";
 	private static final String SERVICE_NAME_DEFAULT = "jadas";
 
+    private String configurationName = CONFIGURATION_NAME_DEFAULT;
 	private String serviceName =  SERVICE_NAME_DEFAULT; 
 	private String mainProgramName = MAIN_PRG_DEFAULT; 
 	private String installTarget = TARGET_DEFAULT; 

--- a/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/extension/ApgCommonPackageExtension.java
+++ b/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/extension/ApgCommonPackageExtension.java
@@ -1,5 +1,8 @@
 package com.apgsga.gradle.common.pkg.extension;
 
+import com.apgsga.gradle.repo.extensions.Repo;
+import com.apgsga.gradle.repo.extensions.RepoType;
+import com.apgsga.gradle.repo.extensions.Repos;
 import com.apgsga.gradle.repo.plugin.ApgCommonRepoPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -14,7 +17,6 @@ public class ApgCommonPackageExtension {
 	private static final String APG_OPSDEFAULT = "apg_ops";
 	private static final String RELEASENR_DEFAULT = "1";
 	private static final String VERSION_DEFAULT = "0.1";
-	private static final String JDK_DIST_REPO_NAME_DEFAULT = "apgPlatformDependencies";
 	private static final String JAVADIST_DEFAULT = "jdk-8u191-linux-x64.tar.gz";
 	private static final String JAVADIR_DEFAULT = "jdk1.8.0_191";
 	private static final boolean WEBEMMEDED_DEFAULT = false;
@@ -58,9 +60,14 @@ public class ApgCommonPackageExtension {
 		super();
 		this.project = project;
 		this.supportedServices = supportedServices;
-		ApgCommonRepoPlugin apgCommonRepoPlugin = (ApgCommonRepoPlugin) project.getPlugins().findPlugin(ApgCommonRepoPlugin.PLUGIN_ID);
-		distRepoUrl = apgCommonRepoPlugin.DEFAULT_REMOTE_REPO_URL + "/" + JDK_DIST_REPO_NAME_DEFAULT;
+		initDistRepoUrl();
 	}
+
+    private void initDistRepoUrl() {
+        Repos repos = (Repos) project.getExtensions().findByName(ApgCommonRepoPlugin.COMMMON_REPO_EXTENSION_NAME);
+        Repo javaDistRepo = repos.get(RepoType.JAVA_DIST);
+        distRepoUrl = javaDistRepo.getRepoBaseUrl() + "/" + javaDistRepo.getRepoName();
+    }
 
     public String getServiceName() {
         return serviceName;

--- a/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/extension/ApgCommonPackageExtension.java
+++ b/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/extension/ApgCommonPackageExtension.java
@@ -1,5 +1,7 @@
 package com.apgsga.gradle.common.pkg.extension;
 
+import com.apgsga.gradle.repo.plugin.ApgCommonRepoPlugin;
+import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
 import java.util.Arrays;
@@ -12,7 +14,7 @@ public class ApgCommonPackageExtension {
 	private static final String RELEASENR_DEFAULT = "1";
 	private static final String VERSION_DEFAULT = "0.1";
 	private static final String JDK_DIST_REPO_NAME_DEFAULT = "apgPlatformDependencies";
-	private static final String REPO_BASE_URL_DEFAULT = "https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga/";
+//	private static final String REPO_BASE_URL_DEFAULT = "https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga/";
 	private static final String JAVADIST_DEFAULT = "jdk-8u191-linux-x64.tar.gz";
 	private static final String JAVADIR_DEFAULT = "jdk1.8.0_191";
 	private static final boolean WEBEMMEDED_DEFAULT = false;
@@ -43,8 +45,7 @@ public class ApgCommonPackageExtension {
 	private Boolean webuiEmbedded = WEBEMMEDED_DEFAULT;
 	private String javaDir = JAVADIR_DEFAULT; 
 	private String javaDist = JAVADIST_DEFAULT; 
-	// TODO (che, 25.9) : retrieve baseUrl from common-repo Plugin 
-	private String distRepoUrl = REPO_BASE_URL_DEFAULT + JDK_DIST_REPO_NAME_DEFAULT;
+	private String distRepoUrl;
 	private List<String> supportedServices;
 	private String version = VERSION_DEFAULT; 
 	private String releaseNr = RELEASENR_DEFAULT; 
@@ -56,6 +57,8 @@ public class ApgCommonPackageExtension {
 		super();
 		this.project = project;
 		this.supportedServices = supportedServices;
+		ApgCommonRepoPlugin apgCommonRepoPlugin = (ApgCommonRepoPlugin) project.getPlugins().findPlugin(ApgCommonRepoPlugin.PLUGIN_ID);
+		distRepoUrl = apgCommonRepoPlugin.DEFAULT_REMOTE_REPO_URL + "/" + JDK_DIST_REPO_NAME_DEFAULT;
 	}
 
 	public String getServiceName() {

--- a/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/extension/ApgCommonPackageExtension.java
+++ b/common-service-packager/src/main/java/com/apgsga/gradle/common/pkg/extension/ApgCommonPackageExtension.java
@@ -14,7 +14,6 @@ public class ApgCommonPackageExtension {
 	private static final String RELEASENR_DEFAULT = "1";
 	private static final String VERSION_DEFAULT = "0.1";
 	private static final String JDK_DIST_REPO_NAME_DEFAULT = "apgPlatformDependencies";
-//	private static final String REPO_BASE_URL_DEFAULT = "https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga/";
 	private static final String JAVADIST_DEFAULT = "jdk-8u191-linux-x64.tar.gz";
 	private static final String JAVADIR_DEFAULT = "jdk1.8.0_191";
 	private static final boolean WEBEMMEDED_DEFAULT = false;

--- a/common-test/src/main/groovy/com/apgsga/gradle/test/utils/AbstractSpecification.groovy
+++ b/common-test/src/main/groovy/com/apgsga/gradle/test/utils/AbstractSpecification.groovy
@@ -113,7 +113,7 @@ abstract class AbstractSpecification extends Specification {
       "MAVEN": "maven"
     },
     {
-      "JAVA_DIST": "java-dist"
+      "JAVA_DIST": "apgPlatformDependencies-test"
     }
   ],
   "repoUserName": "gradledev-tests-user",


### PR DESCRIPTION
Not extremely proud of it, but apgCommonRepo doesn't expose the Default URL. The default URL is always used in context of a specific Repo, therefore I choose to expose it as a public final variable.

Not sure this is the best thing, what do you think? 

As said, probably not perfect, but enough for a review, and to get an idea of what was required.

Even if not perfect, I still like the idea to get the URL from apgCommonRepo ...