### PR TITLE
IT-35456 / new plugin: zip-ssh-deployer

### DIFF
--- a/plugins/settings.gradle
+++ b/plugins/settings.gradle
@@ -14,6 +14,7 @@ include 'rpm-ssh-deployer'
 include 'ssh-common'
 include 'docker-client'
 include 'revision-manager'
+include 'zip-ssh-deployer'
 
 project(':common-repo').projectDir = "$rootDir/common-repo" as File
 project(':generic-publish').projectDir = "$rootDir/generic-publish" as File
@@ -30,5 +31,6 @@ project(':rpm-ssh-deployer').projectDir = "$rootDir/rpm-ssh-deployer" as File
 project(':ssh-common').projectDir = "$rootDir/ssh-common" as File
 project(':docker-client').projectDir = "$rootDir/docker-client" as File
 project(':revision-manager').projectDir = "$rootDir/revision-manager" as File
+project(':zip-ssh-deployer').projectDir = "$rootDir/zip-ssh-deployer" as File
 
 

--- a/plugins/zip-ssh-deployer/build.gradle
+++ b/plugins/zip-ssh-deployer/build.gradle
@@ -1,0 +1,29 @@
+apply from: "${projectDir}/../gradle-common/common-plugin.gradle"
+apply from: "${projectDir}/../gradle-common/integration-test.gradle"
+apply from: "${projectDir}/../gradle-common/functional-test.gradle"
+
+description 'Provides standardized way to execute command via SSH for ZIP deploy and install'
+
+sourceSets {
+    main {
+        java {
+            srcDirs = []
+        }
+        groovy {
+            srcDirs = ['src/main/groovy', 'src/main/java']
+        }
+    }
+}
+
+dependencies {
+    testCompile gradleTestKit()
+    testCompile project(':common-test')
+    compile group: 'com.google.guava', name: 'guava', version: '11.0.2'
+    // TODO JHE: common-repo needed here because of our test which by default include ENUM coming from common-repo
+    //           BUT: in worse case, testCompile should be enough, doesn't seem to be the case
+    //                best case, this dependency should be resolved within common-test or within gradle-common (functionalTest.gradle)
+    compile project(':common-repo')
+    compile group: 'org.springframework', name: 'spring-core', version: '5.2.1.RELEASE'
+    compile group: "org.hidetake", name: 'gradle-ssh-plugin', version: '2.10.1'
+    compile project(':ssh-common')
+}

--- a/plugins/zip-ssh-deployer/src/functionalTest/groovy/com/apgsga/gradle/ssh/zip/deployer/BuildLogicFunctionalTests.groovy
+++ b/plugins/zip-ssh-deployer/src/functionalTest/groovy/com/apgsga/gradle/ssh/zip/deployer/BuildLogicFunctionalTests.groovy
@@ -1,0 +1,123 @@
+package com.apgsga.gradle.ssh.zip.deployer
+
+import com.apgsga.gradle.test.utils.AbstractSpecification
+import org.springframework.core.io.ClassPathResource
+import spock.lang.Ignore
+
+// TODO (jhe, che, 14.2) These tests are because of che's reequest.
+// TODO  But, need to be rethought on the background of integration tests with jenkins docker
+// TODO They introduce a dependency to jenkins-t
+@Ignore
+class BuildLogicFunctionalTests extends AbstractSpecification {
+
+    def "Basic SSH configuration works"() {
+        given:
+            buildFile << """
+                        plugins {
+                            id 'com.apgsga.zip.ssh.deployer' 
+                        }
+                        apgZipDeployConfig {
+                            zipFilePath 'build/output'
+                            zipFileName 'fakeZip.zip'
+                            remoteDeployDestFolder '/etc/installer'
+                            remoteExtractDestFolder '/bin/placeToBeInstalled'
+                        }				
+                        apgZipDeployConfig.log()
+                    """
+        when:
+            def result = gradleRunnerFactory(['init']).build()
+        then:
+            println "Result output: ${result.output}"
+            result.output.contains("zipFilePath='build/output'")
+            result.output.contains("zipFileName='fakeZip.zip'")
+            result.output.contains("remoteDeployDestFolder='/etc/installer'")
+            result.output.contains("remoteExtractDestFolder='/bin/placeToBeInstalled'")
+    }
+
+    def "Deploy and install ZIP Tasks works against test environment for dummy ZIP with dest installation folder"() {
+        given:
+            def zipResource = new ClassPathResource("dummy.zip")
+            def zipFileName = zipResource.getFilename()
+            def zipParentFolder = zipResource.getURI().getPath() - zipFileName
+            buildFile << """
+                            buildscript {
+                                repositories {
+                                    mavenLocal()
+                                    mavenCentral()
+                                    jcenter()
+                                }
+                            
+                                dependencies {
+                                        classpath 'nu.studer:gradle-credentials-plugin:1.0.7'
+                                }
+                            }
+    
+                            plugins {
+                                id 'com.apgsga.zip.ssh.deployer'
+                            }
+    
+                            apply plugin: 'nu.studer.credentials'
+    
+                            apgSshCommon {
+                               username 'apg_install'
+                               userpwd credentials.apg_install
+                               destinationHost 'jenkins-t.apgsga.ch'
+                            }
+                            
+                            apgZipDeployConfig {
+                                zipFilePath '${zipParentFolder}'
+                                zipFileName '${zipFileName}'
+                                remoteDeployDestFolder '/home/apg_install'
+                                remoteExtractDestFolder '/home/apg_install/targetFolderForInstallation'
+                            }				
+                        """
+        when:
+            def result = gradleRunnerFactory(['init','deployZip','installZip']).build()
+        then:
+            result.output.toString().trim() ==~ /(?ms).*Started command.*dummy.zip.*/
+            result.output.toString().trim() ==~ /(?ms).*Success command.*dummy.zip.*/
+    }
+
+    def "Deploy and install ZIP Tasks works against test environment for dummy ZIP without dest installation folder"() {
+        given:
+            def zipResource = new ClassPathResource("dummy.zip")
+            def zipFileName = zipResource.getFilename()
+            def zipParentFolder = zipResource.getURI().getPath() - zipFileName
+            buildFile << """
+                                buildscript {
+                                    repositories {
+                                        mavenLocal()
+                                        mavenCentral()
+                                        jcenter()
+                                    }
+                                
+                                    dependencies {
+                                            classpath 'nu.studer:gradle-credentials-plugin:1.0.7'
+                                    }
+                                }
+        
+                                plugins {
+                                    id 'com.apgsga.zip.ssh.deployer'
+                                }
+        
+                                apply plugin: 'nu.studer.credentials'
+        
+                                apgSshCommon {
+                                   username 'apg_install'
+                                   userpwd credentials.apg_install
+                                   destinationHost 'jenkins-t.apgsga.ch'
+                                }
+                                
+                                apgZipDeployConfig {
+                                    zipFilePath '${zipParentFolder}'
+                                    zipFileName '${zipFileName}'
+                                    remoteDeployDestFolder '/home/apg_install'
+                                }				
+                            """
+        when:
+            def result = gradleRunnerFactory(['init','deployZip','installZip']).build()
+        then:
+            result.output.toString().trim() ==~ /(?ms).*Started command.*dummy.zip.*/
+            result.output.toString().trim() ==~ /(?ms).*Success command.*dummy.zip.*/
+    }
+}

--- a/plugins/zip-ssh-deployer/src/main/groovy/com/apgsga/gradle/ssh/zip/tasks/AbstractZip.groovy
+++ b/plugins/zip-ssh-deployer/src/main/groovy/com/apgsga/gradle/ssh/zip/tasks/AbstractZip.groovy
@@ -1,0 +1,40 @@
+package com.apgsga.gradle.ssh.zip.tasks
+
+import com.apgsga.gradle.ssh.zip.deployer.plugins.ApgZipSshDeployer
+import com.apgsga.ssh.common.extensions.ApgSshCommon
+import com.apgsga.ssh.common.plugin.ApgSshCommonPlugin
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+import org.hidetake.groovy.ssh.core.Remote
+import org.springframework.util.Assert
+
+abstract class AbstractZip extends DefaultTask {
+
+    def getSshConfig() {
+        return (ApgSshCommon) project.getExtensions().findByName(ApgSshCommonPlugin.APG_SSH_COMMON_EXTENSION_NAME)
+    }
+
+    def preConditions(def apgZipDeployConfigExt, def apgSshCommonExt) {
+        Assert.notNull(apgSshCommonExt.username, "${ApgZipSshDeployer.APG_ZIP_DEPLOY_PLUGIN_ID} requires a user name to be configured")
+        Assert.notNull(apgSshCommonExt.userpwd, "${ApgZipSshDeployer.APG_ZIP_DEPLOY_PLUGIN_ID} requires a user password to be configured")
+        Assert.notNull(apgSshCommonExt.destinationHost, "${ApgZipSshDeployer.APG_ZIP_DEPLOY_PLUGIN_ID} requires a destination host to be configured")
+        Assert.notNull(apgZipDeployConfigExt.zipFilePath, "${ApgZipSshDeployer.APG_ZIP_DEPLOY_CONFIG_EXTENSION_NAME} requires a zipFilePath to be configured")
+        Assert.notNull(apgZipDeployConfigExt.zipFileName, "${ApgZipSshDeployer.APG_ZIP_DEPLOY_CONFIG_EXTENSION_NAME} requires a zipFileName to be configured")
+        Assert.notNull(apgZipDeployConfigExt.remoteDeployDestFolder, "${ApgZipSshDeployer.APG_ZIP_DEPLOY_CONFIG_EXTENSION_NAME} requires a remoteDeployDestFolder to be configured")
+    }
+
+    def getDeployConfig() {
+        return project.extensions."${ApgZipSshDeployer.APG_ZIP_DEPLOY_CONFIG_EXTENSION_NAME}"
+    }
+
+    def getRemotes() {
+        def apgSshCommonExt = getSshConfig()
+        def apgZipDeployConfigExt = getDeployConfig()
+        preConditions(apgZipDeployConfigExt, apgSshCommonExt)
+        // TODO JHE: in the future, do we want different pre-configured remote for our different target ?
+        return new Remote(["name": "default", "host": "${apgSshCommonExt.destinationHost}", "user": "${apgSshCommonExt.username}", "password": "${apgSshCommonExt.userpwd}"]);
+    }
+
+    @TaskAction
+    abstract def taskAction()
+}

--- a/plugins/zip-ssh-deployer/src/main/groovy/com/apgsga/gradle/ssh/zip/tasks/DeployZip.groovy
+++ b/plugins/zip-ssh-deployer/src/main/groovy/com/apgsga/gradle/ssh/zip/tasks/DeployZip.groovy
@@ -1,0 +1,29 @@
+package com.apgsga.gradle.ssh.zip.tasks
+
+import org.hidetake.groovy.ssh.core.Remote
+
+class DeployZip extends AbstractZip {
+
+    public static final String DEPLOY_ZIP_TASK_NAME = "deployZip"
+
+    @Override
+    def taskAction() {
+        def apgZipDeployConfigExt = getDeployConfig()
+        Remote remotes = getRemotes()
+        project.logger.info("${apgZipDeployConfigExt.zipFileName} will be deploy on ${remotes.getProperty('host')} using ${remotes.getProperty('user')} User")
+        project.ssh.run {
+            if (apgZipDeployConfigExt.allowAnyHosts) {
+                project.logger.info("Allowing SSH Anyhosts ")
+                settings {
+                    knownHosts = allowAnyHosts
+                }
+            }
+            session(remotes) {
+                put from: new File("${apgZipDeployConfigExt.zipFilePath}" + File.separator + apgZipDeployConfigExt.zipFileName), into: "${apgZipDeployConfigExt.remoteDeployDestFolder}"
+                execute("ls -la ${apgZipDeployConfigExt.remoteDeployDestFolder}") { result ->
+                    println result
+                }
+            }
+        }
+    }
+}

--- a/plugins/zip-ssh-deployer/src/main/groovy/com/apgsga/gradle/ssh/zip/tasks/InstallZip.groovy
+++ b/plugins/zip-ssh-deployer/src/main/groovy/com/apgsga/gradle/ssh/zip/tasks/InstallZip.groovy
@@ -1,0 +1,38 @@
+package com.apgsga.gradle.ssh.zip.tasks
+
+import com.apgsga.gradle.ssh.zip.deployer.extensions.ApgZipDeployConfig
+import org.hidetake.groovy.ssh.core.Remote
+
+class InstallZip extends AbstractZip {
+
+    public static final String INTALL_ZIP_TASK_NAME = "installZip"
+
+    @Override
+    def taskAction() {
+        def apgZipDeployConfigExt = getDeployConfig()
+        Remote remotes = getRemotes()
+        project.logger.info("${apgZipDeployConfigExt.zipFileName} will be install on ${remotes.getProperty('host')} using ${remotes.getProperty('user')} User")
+        def unzipCmd = getUnzipCmd(apgZipDeployConfigExt)
+        project.ssh.run {
+            if (apgZipDeployConfigExt.allowAnyHosts) {
+                project.logger.info("Allowing SSH Anyhosts ")
+                settings {
+                    knownHosts = allowAnyHosts
+                }
+            }
+            session(remotes) {
+                executeSudo unzipCmd, pty: true
+                // JHE: it probably won't sty like that, we might not want to delete ZIP which were built for production
+                execute "rm -f ${apgZipDeployConfigExt.remoteDeployDestFolder}/${apgZipDeployConfigExt.zipFileName}", pty: true
+            }
+        }
+    }
+
+    private def getUnzipCmd(ApgZipDeployConfig config) {
+        def cmd = "unzip ${config.remoteDeployDestFolder}/${config.zipFileName}"
+        if(config.remoteExtractDestFolder?.trim()) {
+            cmd += " -d ${config.remoteExtractDestFolder}"
+        }
+        return cmd
+    }
+}

--- a/plugins/zip-ssh-deployer/src/main/java/com/apgsga/gradle/ssh/zip/deployer/extensions/ApgZipDeployConfig.java
+++ b/plugins/zip-ssh-deployer/src/main/java/com/apgsga/gradle/ssh/zip/deployer/extensions/ApgZipDeployConfig.java
@@ -1,0 +1,68 @@
+package com.apgsga.gradle.ssh.zip.deployer.extensions;
+
+import org.gradle.api.Project;
+
+public class ApgZipDeployConfig {
+
+    private final Project project;
+
+    private String zipFilePath;
+    private String zipFileName;
+    private String remoteDeployDestFolder;
+    private String remoteExtractDestFolder;
+    private Boolean allowAnyHosts = false;
+
+    public ApgZipDeployConfig(Project project) {
+        this.project = project;
+    }
+
+    public String getZipFileName() {
+        return zipFileName;
+    }
+
+    public void setZipFileName(String zipFileName) {
+        this.zipFileName = zipFileName;
+    }
+
+    public String getZipFilePath() {
+        return zipFilePath;
+    }
+
+    public void setZipFilePath(String zipFilePath) {
+        this.zipFilePath = zipFilePath;
+    }
+
+    public String getRemoteDeployDestFolder() {
+        return remoteDeployDestFolder;
+    }
+
+    public void setRemoteDeployDestFolder(String remoteDeployDestFolder) { this.remoteDeployDestFolder = remoteDeployDestFolder; }
+
+    public String getRemoteExtractDestFolder() { return remoteExtractDestFolder; }
+
+    public void setRemoteExtractDestFolder(String remoteExtractDestFolder) { this.remoteExtractDestFolder = remoteExtractDestFolder; }
+
+    public Boolean getAllowAnyHosts() {
+        return allowAnyHosts;
+    }
+
+    public void setAllowAnyHosts(Boolean allowAnyHosts) {
+        this.allowAnyHosts = allowAnyHosts;
+    }
+
+    public void log() {
+        System.out.println(toString());
+    }
+
+    @Override
+    public String toString() {
+        return "ApgZipDeployConfig{" +
+                "project=" + project +
+                ", zipFilePath='" + zipFilePath + '\'' +
+                ", zipFileName='" + zipFileName + '\'' +
+                ", remoteDeployDestFolder='" + remoteDeployDestFolder + '\'' +
+                ", remoteExtractDestFolder='" + remoteExtractDestFolder + '\'' +
+                ", allowAnyHosts=" + allowAnyHosts +
+                '}';
+    }
+}

--- a/plugins/zip-ssh-deployer/src/main/java/com/apgsga/gradle/ssh/zip/deployer/plugins/ApgZipSshDeployer.java
+++ b/plugins/zip-ssh-deployer/src/main/java/com/apgsga/gradle/ssh/zip/deployer/plugins/ApgZipSshDeployer.java
@@ -1,0 +1,29 @@
+package com.apgsga.gradle.ssh.zip.deployer.plugins;
+
+import com.apgsga.gradle.ssh.zip.deployer.extensions.ApgZipDeployConfig;
+import com.apgsga.gradle.ssh.zip.tasks.DeployZip;
+import com.apgsga.gradle.ssh.zip.tasks.InstallZip;
+import com.apgsga.ssh.common.plugin.ApgSshCommonPlugin;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskContainer;
+
+public class ApgZipSshDeployer implements Plugin<Project> {
+
+    public static final String APG_ZIP_DEPLOY_CONFIG_EXTENSION_NAME = "apgZipDeployConfig";
+
+    public static final String APG_ZIP_DEPLOY_PLUGIN_ID = "com.apgsga.zip.ssh.deployer";
+
+    private Project project;
+
+    @Override
+    public void apply(Project project) {
+        this.project = project;
+        project.getExtensions().create(APG_ZIP_DEPLOY_CONFIG_EXTENSION_NAME, ApgZipDeployConfig.class, project);
+        project.getPlugins().apply("org.hidetake.ssh");
+        project.getPlugins().apply(ApgSshCommonPlugin.APG_SSH_COMMON_PLUGIN_ID);
+        TaskContainer tasks = project.getTasks();
+        tasks.register(DeployZip.DEPLOY_ZIP_TASK_NAME, DeployZip.class);
+        tasks.register(InstallZip.INTALL_ZIP_TASK_NAME, InstallZip.class);
+    }
+}

--- a/plugins/zip-ssh-deployer/src/main/resources/META-INF/gradle-plugins/com.apgsga.zip.ssh.deployer.properties
+++ b/plugins/zip-ssh-deployer/src/main/resources/META-INF/gradle-plugins/com.apgsga.zip.ssh.deployer.properties
@@ -1,0 +1,1 @@
+implementation-class=com.apgsga.gradle.ssh.zip.deployer.plugins.ApgZipSshDeployer


### PR DESCRIPTION
We probably have parts which could be factorized out together with "rpm-ssh-deployer". However, as a first version, I though to keep things completely separated to first see how it will evolve after first integration (typically with Digiflex).
So for now it's something brand new, probably safe to be merged :)

 @apgsga-stb, @apgsga-uge : FYI


