### PR TITLE
IT-35481 / First part, users and passwords moved into encrypted file

### DIFF
--- a/integration/jenkins-pipeline-tests/build.gradle
+++ b/integration/jenkins-pipeline-tests/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id("com.apgsga.ssh")
 }
 apply plugin: JenkinsRunner
+apply plugin: 'nu.studer.credentials'
 
 apgSshConfig {
     username = credentials.jheUser

--- a/plugins/common-repo/build.gradle
+++ b/plugins/common-repo/build.gradle
@@ -20,4 +20,5 @@ dependencies {
 	compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.8.4'
 	compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.8.4'
 	compile group: 'nu.studer', name: 'gradle-credentials-plugin', version: '2.1'
+
 }

--- a/plugins/common-repo/build.gradle
+++ b/plugins/common-repo/build.gradle
@@ -19,4 +19,5 @@ dependencies {
 	compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.8.4'
 	compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.8.4'
 	compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.8.4'
+	compile group: 'nu.studer', name: 'gradle-credentials-plugin', version: '2.1'
 }

--- a/plugins/common-repo/src/functionalTest/groovy/com/apgsga/gradle/repo/plugin/BuildLogicFunctionalTest.groovy
+++ b/plugins/common-repo/src/functionalTest/groovy/com/apgsga/gradle/repo/plugin/BuildLogicFunctionalTest.groovy
@@ -109,4 +109,23 @@ class BuildLogicFunctionalTest extends AbstractSpecification {
 			result.output.contains('repoName=maven')
 			result.output.contains('repoName=apgPlatformDependencies-test')
 	}
+
+	def "Default repoBaseUrl, default user and default password work"() {
+		// JHE: we arbitrarly test against maven Repo
+		given:
+			buildFile << """
+					plugins {
+						id 'com.apgsga.common.repo' 
+					}
+					apgRepos.get(MAVEN).log()
+				"""
+		when:
+			def result = gradleRunnerFactory(['init']).build()
+		then:
+			println "Result output: ${result.output}"
+			result.output.contains('repoName=maven')
+			result.output.contains('user=gradledev-tests-user')
+			result.output.contains('password=xxxxxx')
+			result.output.contains('repoBaseUrl=https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga')
+	}
 }

--- a/plugins/common-repo/src/main/java/com/apgsga/gradle/repo/plugin/ApgCommonRepoPlugin.java
+++ b/plugins/common-repo/src/main/java/com/apgsga/gradle/repo/plugin/ApgCommonRepoPlugin.java
@@ -3,10 +3,15 @@ package com.apgsga.gradle.repo.plugin;
 import com.apgsga.gradle.repo.extensions.ApgRepo;
 import com.apgsga.gradle.repo.extensions.RepoType;
 import com.apgsga.gradle.repo.extensions.ReposImpl;
+import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import nu.studer.gradle.credentials.AddCredentialsTask;
+import nu.studer.gradle.credentials.domain.CredentialsContainer;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.plugins.ExtensionContainer;
 import org.springframework.core.io.FileSystemResourceLoader;
 import org.springframework.core.io.Resource;
@@ -29,6 +34,7 @@ public class ApgCommonRepoPlugin implements Plugin<Project> {
 	@Override
 	public void apply(final Project project) {
 		this.project = project;
+		project.getPlugins().apply("nu.studer.credentials");
 		final ExtensionContainer ext = project.getExtensions();
 		ReposImpl reposImpl = ext.create(COMMMON_REPO_EXTENSION_NAME, ReposImpl.class, project);
 
@@ -42,10 +48,31 @@ public class ApgCommonRepoPlugin implements Plugin<Project> {
 
 	private RepoNamesBean loadRepoNames() {
 		try {
-			return new ObjectMapper().readerFor(RepoNamesBean.class).readValue(getRepoNameResource().getFile());
+			RepoNamesBean bean = new ObjectMapper().readerFor(RepoNamesBean.class).readValue(getRepoNameResource().getFile());
+			bean.repoUserPwd = getRepoUserPassword();
+			bean.repoUserName = getRepoUserName();
+			bean.repoBaseUrl = getRepoBaseUrl();
+			return bean;
 		} catch (IOException e) {
-			throw new RuntimeException("Problem while deserializing " + REPO_NAMES_JSON_FILENAME + ". Original esxception was: " + e.getMessage());
+			throw new RuntimeException("Problem while deserializing " + REPO_NAMES_JSON_FILENAME + ". Original exception was: " + e.getMessage());
 		}
+	}
+
+	private String getRepoUserName() {
+		return (String) getCredentialsContainer().propertyMissing("mavenRepoUser");
+	}
+
+	private String getRepoUserPassword() {
+		return (String) getCredentialsContainer().propertyMissing("mavenRepoPwd");
+	}
+
+	private CredentialsContainer getCredentialsContainer() {
+		// credentials Property comes from the nu.studer.credentials plugin
+		return (CredentialsContainer) project.getExtensions().getExtraProperties().get("credentials");
+	}
+
+	private String getRepoBaseUrl() {
+		return (String) project.getExtensions().getExtraProperties().get("mavenRepoBaseUrl");
 	}
 
 	private Resource getRepoNameResource() {

--- a/plugins/common-repo/src/main/java/com/apgsga/gradle/repo/plugin/ApgCommonRepoPlugin.java
+++ b/plugins/common-repo/src/main/java/com/apgsga/gradle/repo/plugin/ApgCommonRepoPlugin.java
@@ -34,7 +34,7 @@ public class ApgCommonRepoPlugin implements Plugin<Project> {
 	@Override
 	public void apply(final Project project) {
 		this.project = project;
-		project.getPlugins().apply("nu.studer.credentials");
+		//project.getPlugins().apply("nu.studer.credentials");
 		final ExtensionContainer ext = project.getExtensions();
 		ReposImpl reposImpl = ext.create(COMMMON_REPO_EXTENSION_NAME, ReposImpl.class, project);
 

--- a/plugins/common-repo/src/main/java/com/apgsga/gradle/repo/plugin/ApgCommonRepoPlugin.java
+++ b/plugins/common-repo/src/main/java/com/apgsga/gradle/repo/plugin/ApgCommonRepoPlugin.java
@@ -3,15 +3,11 @@ package com.apgsga.gradle.repo.plugin;
 import com.apgsga.gradle.repo.extensions.ApgRepo;
 import com.apgsga.gradle.repo.extensions.RepoType;
 import com.apgsga.gradle.repo.extensions.ReposImpl;
-import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import nu.studer.gradle.credentials.AddCredentialsTask;
 import nu.studer.gradle.credentials.domain.CredentialsContainer;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.plugins.ExtensionContainer;
 import org.springframework.core.io.FileSystemResourceLoader;
 import org.springframework.core.io.Resource;
@@ -34,7 +30,7 @@ public class ApgCommonRepoPlugin implements Plugin<Project> {
 	@Override
 	public void apply(final Project project) {
 		this.project = project;
-		//project.getPlugins().apply("nu.studer.credentials");
+		project.getPlugins().apply("nu.studer.credentials");
 		final ExtensionContainer ext = project.getExtensions();
 		ReposImpl reposImpl = ext.create(COMMMON_REPO_EXTENSION_NAME, ReposImpl.class, project);
 

--- a/plugins/common-repo/src/main/java/com/apgsga/gradle/repo/plugin/RepoNamesBean.java
+++ b/plugins/common-repo/src/main/java/com/apgsga/gradle/repo/plugin/RepoNamesBean.java
@@ -8,13 +8,10 @@ import java.util.Map;
 
 public class RepoNamesBean {
 
-    @JsonProperty
     public String repoUserName;
 
-    @JsonProperty
     public String repoUserPwd;
 
-    @JsonProperty
     public String repoBaseUrl;
 
     @JsonProperty

--- a/plugins/common-test/src/main/groovy/com/apgsga/gradle/test/utils/AbstractSpecification.groovy
+++ b/plugins/common-test/src/main/groovy/com/apgsga/gradle/test/utils/AbstractSpecification.groovy
@@ -17,9 +17,7 @@ abstract class AbstractSpecification extends Specification {
         setupTestProjectDir()
         createBuildFile()
         createGradleHomeDir()
-        // TODO JHE: Might not be needed anymore with IT-35189
         createGradleProperties()
-        // TODO JHE: Might not be needed anymore with IT-35189
         createGradleEncryptedProperties()
         setupRepoNameJson()
     }
@@ -87,6 +85,11 @@ abstract class AbstractSpecification extends Specification {
         gradleEncyrpytedProperties << System.getProperty("line.separator")
         gradleEncyrpytedProperties << "mavenRepoPwd=jTgfLqung5Pw4VQqSldeUEK9NG/HslI+GjGZ2aqtdx8\\="
         println "${gradleEncyrpytedProperties.absolutePath} has been created!"
+    }
+
+    private def createApgInfoFile(String parentPath) {
+        File apgInfo = new File("${parentPath}/ApgInfo.gradle")
+        apgInfo << "println \"Properties have been initiliazed for testing purpose via AbstractSpecification class\""
     }
 
     private def setupRepoNameJson() {

--- a/plugins/common-test/src/main/groovy/com/apgsga/gradle/test/utils/AbstractSpecification.groovy
+++ b/plugins/common-test/src/main/groovy/com/apgsga/gradle/test/utils/AbstractSpecification.groovy
@@ -87,11 +87,6 @@ abstract class AbstractSpecification extends Specification {
         println "${gradleEncyrpytedProperties.absolutePath} has been created!"
     }
 
-    private def createApgInfoFile(String parentPath) {
-        File apgInfo = new File("${parentPath}/ApgInfo.gradle")
-        apgInfo << "println \"Properties have been initiliazed for testing purpose via AbstractSpecification class\""
-    }
-
     private def setupRepoNameJson() {
         File repoNamesJson = new File(gradleHomeDirPath, "repoNames.json")
         initTepoNamesJsonContent(repoNamesJson)

--- a/plugins/common-test/src/main/groovy/com/apgsga/gradle/test/utils/AbstractSpecification.groovy
+++ b/plugins/common-test/src/main/groovy/com/apgsga/gradle/test/utils/AbstractSpecification.groovy
@@ -22,7 +22,6 @@ abstract class AbstractSpecification extends Specification {
         // TODO JHE: Might not be needed anymore with IT-35189
         createGradleEncryptedProperties()
         setupRepoNameJson()
-        setupSupportedServicesJson()
     }
 
     private def createBuildFile() {
@@ -75,26 +74,19 @@ abstract class AbstractSpecification extends Specification {
         gradleProperties << "config.dir=src/functionalTest/resources/config"
         gradleProperties << System.getProperty("line.separator")
         gradleProperties << "target.system.mapping.file.name=TargetSystemMappings.json"
+        gradleProperties << System.getProperty("line.separator")
+        gradleProperties << "mavenRepoBaseUrl=https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga"
         println "${gradleProperties.absolutePath} has been created!"
     }
 
     def createGradleEncryptedProperties() {
         File gradleEncyrpytedProperties = new File("${gradleHomeDirPath}/gradle.encrypted.properties")
         gradleEncyrpytedProperties << "apg_install=tAAMlNlXrCjnphgKtCkHHZLkezTSeM1QwZ4+kfXyMaM\\="
+        gradleEncyrpytedProperties << System.getProperty("line.separator")
+        gradleEncyrpytedProperties << "mavenRepoUser=jTgfLqung5Pw4VQqSldeUEK9NG/HslI+GjGZ2aqtdx8\\="
+        gradleEncyrpytedProperties << System.getProperty("line.separator")
+        gradleEncyrpytedProperties << "mavenRepoPwd=jTgfLqung5Pw4VQqSldeUEK9NG/HslI+GjGZ2aqtdx8\\="
         println "${gradleEncyrpytedProperties.absolutePath} has been created!"
-    }
-
-    def setupSupportedServicesJson() {
-        File installableServicesJson = new File(gradleHomeDirPath, "supportedServices.json")
-        initSupportedServicesJsonContent(installableServicesJson)
-    }
-
-    def initSupportedServicesJsonContent(File file) {
-        file << """
-            {
-                "supportedServices": ["jadas","digiflex","vkjadas","interjadas","interweb","testapp"]
-            }
-        """
     }
 
     private def setupRepoNameJson() {
@@ -105,35 +97,32 @@ abstract class AbstractSpecification extends Specification {
     private static def initTepoNamesJsonContent(File repoNames) {
         repoNames << """
 
-    {
-  "repos": [
-    {
-      "ZIP": "release-functionaltest"
-    },
-    {
-      "RPM": "rpm-functionaltest"
-    },
-    {
-      "MAVEN_SNAPSHOT": "snapshot-functionaltest"
-    },
-    {
-      "MAVEN_RELEASE": "release-functionaltest"
-    },
-    {
-      "LOCAL": "local"
-    },
-    {
-      "MAVEN": "maven"
-    },
-    {
-      "JAVA_DIST": "apgPlatformDependencies-test"
-    }
-  ],
-  "repoUserName": "gradledev-tests-user",
-  "repoUserPwd": "gradledev-tests-user",
-  "repoBaseUrl": "https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga"
-}
-"""
+                {
+              "repos": [
+                {
+                  "ZIP": "release-functionaltest"
+                },
+                {
+                  "RPM": "rpm-functionaltest"
+                },
+                {
+                  "MAVEN_SNAPSHOT": "snapshot-functionaltest"
+                },
+                {
+                  "MAVEN_RELEASE": "release-functionaltest"
+                },
+                {
+                  "LOCAL": "local"
+                },
+                {
+                  "MAVEN": "maven"
+                },
+                {
+                  "JAVA_DIST": "apgPlatformDependencies-test"
+                }
+              ]
+            }
+            """
     }
 
     protected def gradleRunnerFactory() {

--- a/plugins/gradle-common/common-plugin.gradle
+++ b/plugins/gradle-common/common-plugin.gradle
@@ -1,10 +1,21 @@
+buildscript {
+	repositories {
+		gradlePluginPortal()
+	}
+	dependencies {
+		classpath 'nu.studer:gradle-credentials-plugin:2.1'
+	}
+}
+
 apply plugin: 'groovy'
 apply plugin: 'java-gradle-plugin'
 apply plugin: 'maven-publish'
 apply plugin: 'eclipse'
+apply plugin: nu.studer.gradle.credentials.CredentialsPlugin
 
 group = 'com.apgsga.gradle'
 version = '1.1-SNAPSHOT'
+
 
 def devUser = project.credentials.devUser
 def devPw = project.credentials.devPw


### PR DESCRIPTION
This pull request is for the first part of IT-35481, where we want to move users and passwords into our encrypted file. Also, repoNames.json has been updated and contain now only repo definition, no more username, password and repoUrl.

I also modified our apg-gradle-properties on `git.apgsga.ch:/var/git/repos/apg-gradle-properties.git`. There you also find a branch called "jhe_it-35481". If you're OK with this pull request, then I'll merge the apg-gradle-properties modification on "master".

The idea is that we merge this one. Then I'll test that everything still works with what has previously been merged from https://github.com/apgsga-it/apg-gradle-plugins/pull/40 . If all good, I'll then continue with the second part of IT-35481 where we want to add profiles.

CAREFUL: this pull request has nothing to do with IT-35568 in which we want to "_Alignment used credentials for target Gradle build scripts_". This will be done afterwards, when all user will first be in a centralized place (aim of this pull request).