### PR TITLE
IT-35985 / Gradle caching Maven SNAPSHOT Dependencies

### DIFF
--- a/plugins/common-repo/src/functionalTest/groovy/com/apgsga/gradle/repo/plugin/BuildLogicFunctionalTest.groovy
+++ b/plugins/common-repo/src/functionalTest/groovy/com/apgsga/gradle/repo/plugin/BuildLogicFunctionalTest.groovy
@@ -6,6 +6,38 @@ import spock.lang.Ignore
 
 class BuildLogicFunctionalTest extends AbstractSpecification {
 
+    def "Test build, publish locally only from a project having an external dependency by explicitly specifying a profile"() {
+        given:
+        buildFile << """
+                                    plugins {
+                                        id 'com.apgsga.common.repo' 
+                                        id 'maven-publish'
+                                    }
+        
+                                    apply plugin: 'groovy'
+                                    apply plugin: 'java-gradle-plugin'
+                                    
+                                    group = 'com.apgsga.jhe'
+                                    version = '1.0'
+        
+                                    dependencies {
+                                        compile group: 'com.google.guava', name: 'guava', version: '11.0.2'
+                                    }
+                                    
+                                    publishing {
+                                        repositories {
+                                           maven {
+                                                name = 'local'
+                                           }
+                                        } 
+                                     }                                    
+                                """
+        when:
+        def result = gradleRunnerFactory(['clean', 'build', 'publish']).build()
+        then:
+        println "Result output: ${result.output}"
+    }
+
     @Ignore
     def "Test build, publish locally and remote from a project having an external dependency by explicitly specifying a profile"() {
         given:

--- a/plugins/common-repo/src/functionalTest/resources/testMavenSettings.xml
+++ b/plugins/common-repo/src/functionalTest/resources/testMavenSettings.xml
@@ -25,14 +25,6 @@
                         <enabled>false</enabled>
                     </snapshots>
                     <id>central</id>
-                    <name>local</name>
-                    <url>.</url>
-                </repository>
-                <repository>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                    <id>central</id>
                     <name>gradle_maven_releases</name>
                     <url>https://artifactory4t4apgsga.jfrog.io/artifactory/releases-test</url>
                 </repository>


### PR DESCRIPTION
Gradle will have a local repo configured based on information define within maven settings.xml --> tag <localRepository>.
By default, we'll always load such a repo, but this can be deactivated using the following property in gradle.properties:

- apg.common.repo.gradle.local.repo.from.maven=false

I'm not providing the possibility to deactivate it via plugin DSL, because the common-repo plugin is anyway applied before build.gradle will be parse.

The above property can also by default be set to true within the template provided with our project on git: git.apgsga.ch:/var/git/repos/apg-gradle-properties.git
