### PR TITLE
IT-35957 / Revision Handling and Package Server (Gradle Plugin)

### DIFF
--- a/plugins/version-manager/build.gradle.kts
+++ b/plugins/version-manager/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     compile(project(":generic-publish"))
     compile(project(":revision-manager"))
     compile(project(":packaging-tasks"))
+    compile(project(":ssh-tasks"))
     compile("org.slf4j:slf4j-api:1.7.25")
     integrationTestRuntimeOnly("org.slf4j:slf4j-simple:1.7.29")
 

--- a/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
+++ b/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
@@ -108,7 +108,7 @@ open class VersionResolutionExtension(val project: Project, private val revision
     val releasedNr: String?
         get() {
             if(_releasedNr == null) {
-                _releasedNr = _revisionManger?.lastRevision(_serviceName,_installTarget)
+                _releasedNr = revisionManger?.lastRevision(_serviceName,_installTarget)
             }
             return _releasedNr
         }

--- a/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
+++ b/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
@@ -57,6 +57,8 @@ open class VersionResolutionExtension(val project: Project, private val revision
             if (_revisionManger == null) {
                 _revisionManger = revisionManagerBuilder.revisionRootPath(revisionRootPath
                         ?: project.gradle.gradleUserHomeDir.absolutePath).cloneTargetPath(cloneTargetPath).algorithm(algorithm).build()
+
+                // JHE (14.07.2020): we eventually want to do this only for CLONED scenario, not 100% sure yet.
                 val pkgExt = project.extensions.getByType(ApgCommonPackageExtension::class.java)
                 pkgExt.releaseNr = releasedNr
                 val rpmDeployExt = project.extensions.getByType(ApgRpmDeployConfig::class.java)

--- a/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
+++ b/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
@@ -108,7 +108,7 @@ open class VersionResolutionExtension(val project: Project, private val revision
     val releasedNr: String?
         get() {
             if(_releasedNr == null) {
-                _releasedNr = revisionManger?.lastRevision(_serviceName,_installTarget)
+                _releasedNr = revisionManger?.lastRevision(serviceName,installTarget)
             }
             return _releasedNr
         }

--- a/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
+++ b/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
@@ -99,6 +99,14 @@ open class VersionResolutionExtension(val project: Project, private val revision
         set(value) {
             this._bomLastRevision = value
         }
+    private var _releasedNr: String? = null
+    val releaseNr: String
+        get() {
+            if(_releasedNr == null) {
+                _releasedNr = _revisionManger?.lastRevision(_serviceName,_installTarget)
+            }
+            return _releasedNr as String
+        }
 
     init {
         configureConfiguration(configurationName as String)

--- a/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
+++ b/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
@@ -100,12 +100,12 @@ open class VersionResolutionExtension(val project: Project, private val revision
             this._bomLastRevision = value
         }
     private var _releasedNr: String? = null
-    val releaseNr: String
+    val releaseNr: String?
         get() {
             if(_releasedNr == null) {
                 _releasedNr = _revisionManger?.lastRevision(_serviceName,_installTarget)
             }
-            return _releasedNr as String
+            return _releasedNr
         }
 
     init {

--- a/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
+++ b/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
@@ -7,6 +7,7 @@ import com.apgsga.maven.impl.resolver.CompositeVersionResolverBuilder
 import com.apgsga.packaging.extensions.ApgCommonPackageExtension
 import com.apgsga.revision.manager.domain.RevisionManager
 import com.apgsga.revision.manager.domain.RevisionManagerBuilder
+import com.apgsga.ssh.extensions.ApgRpmDeployConfig
 import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.Project
@@ -56,6 +57,10 @@ open class VersionResolutionExtension(val project: Project, private val revision
             if (_revisionManger == null) {
                 _revisionManger = revisionManagerBuilder.revisionRootPath(revisionRootPath
                         ?: project.gradle.gradleUserHomeDir.absolutePath).cloneTargetPath(cloneTargetPath).algorithm(algorithm).build()
+                val pkgExt = project.extensions.getByType(ApgCommonPackageExtension::class.java)
+                pkgExt.releaseNr = releasedNr
+                val rpmDeployExt = project.extensions.getByType(ApgRpmDeployConfig::class.java)
+                rpmDeployExt.rpmFileName = pkgExt.archiveName
             }
             return _revisionManger as RevisionManager
         }
@@ -100,7 +105,7 @@ open class VersionResolutionExtension(val project: Project, private val revision
             this._bomLastRevision = value
         }
     private var _releasedNr: String? = null
-    val releaseNr: String?
+    val releasedNr: String?
         get() {
             if(_releasedNr == null) {
                 _releasedNr = _revisionManger?.lastRevision(_serviceName,_installTarget)

--- a/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/plugin/VersionResolutionPlugin.kt
+++ b/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/plugin/VersionResolutionPlugin.kt
@@ -20,10 +20,18 @@ open class VersionResolutionPlugin : Plugin<Project> {
         val revisionManagerBuilder = RevisionManagerBuilder.create()
         val extension =  project.extensions.create("apgVersionResolver", VersionResolutionExtension::class.java, project, revisionManagerBuilder)
         project.afterEvaluate {
+            setReleaseNrToCommonPackager(project)
             applyRecommendations(project, extension)
         }
 
     }
+
+    private fun setReleaseNrToCommonPackager(project: Project) {
+        val config = project.extensions.getByType(VersionResolutionExtension::class.java)
+        val pkgExt = project.extensions.getByType(ApgCommonPackageExtension::class.java)
+        pkgExt.releaseNr = config.releaseNr
+    }
+
     private fun applyRecommendations(project: Project, resolutionExtension : VersionResolutionExtension) {
         val config = project.configurations.findByName(resolutionExtension.configurationName as String)
         val action = Action<Configuration> {

--- a/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/plugin/VersionResolutionPlugin.kt
+++ b/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/plugin/VersionResolutionPlugin.kt
@@ -20,18 +20,10 @@ open class VersionResolutionPlugin : Plugin<Project> {
         val revisionManagerBuilder = RevisionManagerBuilder.create()
         val extension =  project.extensions.create("apgVersionResolver", VersionResolutionExtension::class.java, project, revisionManagerBuilder)
         project.afterEvaluate {
-            setReleaseNrToCommonPackager(project)
             applyRecommendations(project, extension)
         }
 
     }
-
-    private fun setReleaseNrToCommonPackager(project: Project) {
-        val config = project.extensions.getByType(VersionResolutionExtension::class.java)
-        val pkgExt = project.extensions.getByType(ApgCommonPackageExtension::class.java)
-        pkgExt.releaseNr = config.releaseNr
-    }
-
     private fun applyRecommendations(project: Project, resolutionExtension : VersionResolutionExtension) {
         val config = project.configurations.findByName(resolutionExtension.configurationName as String)
         val action = Action<Configuration> {


### PR DESCRIPTION
The packaging and deploying tasks also have to be set with the correct releaseNr. In order to set it, I used the lastRevision coming from Revisions.json for a particular service. These information are set from the version-manager. I could test it locally on my VM using the following DSL (here just an extract) for the "digiflex-jadas-pkg" project:

```
apgPackage {
	name = "digiflex-jadas"
	configurationName = "serviceRuntime"
	dependencies = [
		"com.apgsga.it21.ui.mdt:jadas-app-starter",
		"com.apgsga.it21.ui.mdt:jadas-framework-starter"
	]
	resourceFilters = "serviceport:it21db-jadas:ibdsdb-jadas:ecmservice:interapp:javamelody"
	appConfigFilters = "general:jadas"
	resourcesPath = "resources"
	installTarget = project.ext.installTarget
	mainProgramName  = "com.apgsga.it21.ui.webapp.Webapp"
}

apgRpmDeployConfig {
	rpmFilePath "${buildDir}/distributions/"
	rpmFileName "${apgPackage.archiveName}"
	remoteDestFolder "${project.ext.downloadDir}"
}
```

What do you think?