### PR TITLE
IT-35962 / Service Patch Packages Install

### DIFF
--- a/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/general/tasks/SshPutTask.groovy
+++ b/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/general/tasks/SshPutTask.groovy
@@ -23,6 +23,7 @@ class SshPutTask extends AbstractSshTask {
                 }
             }
             session(remote) {
+                execute "mkdir -p ${into}" // will create dest folder if it does not exist
                 put from: from,  into: into
             }
         }

--- a/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/rpm/tasks/AbstractRpm.groovy
+++ b/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/rpm/tasks/AbstractRpm.groovy
@@ -19,7 +19,6 @@ abstract class AbstractRpm extends AbstractSshTask {
         Assert.notNull(apgSshConfig.userpwd, "${ApgSsh.PLUGIN_ID} requires a user password to be configured")
         Assert.notNull(apgSshConfig.destinationHost, "${ApgSsh.PLUGIN_ID} requires a destination host to be configured")
         Assert.notNull(apgRpmDeployConfigExt.rpmFilePath, "${ApgSsh.APG_RPM_DEPLOY_CONFIG_EXTENSION_NAME} requires a rpmFilePath to be configured")
-        Assert.notNull(apgRpmDeployConfigExt.rpmFileName, "${ApgSsh.APG_RPM_DEPLOY_CONFIG_EXTENSION_NAME} requires a rpmFileName to be configured")
         Assert.notNull(apgRpmDeployConfigExt.remoteDestFolder, "${ApgSsh.APG_RPM_DEPLOY_CONFIG_EXTENSION_NAME} requires a remoteDestFolder to be configured")
     }
 

--- a/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/rpm/tasks/InstallRpm.groovy
+++ b/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/rpm/tasks/InstallRpm.groovy
@@ -17,7 +17,7 @@ class InstallRpm extends AbstractRpm {
                 }
             }
             session(remote) {
-                executeSudo "f=\$(ls -t1 ${apgRpmDeployConfigExt.remoteDestFolder}/*.rpm | head -n 1) && rpm -Uvh \$f", pty: true
+                execute "f=\$(ls -t1 ${apgRpmDeployConfigExt.remoteDestFolder}/*.rpm | head -n 1) && sudo rpm -Uvh \$f", pty: true
                 // JHE: this probably won't stay like that, as we won't want to delete a production RPM before having archiving it. But quick fix for now for Digiflex
                 execute "rm -f ${apgRpmDeployConfigExt.remoteDestFolder}/${apgRpmDeployConfigExt.rpmFileName}", pty: true
             }

--- a/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/rpm/tasks/InstallRpm.groovy
+++ b/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/rpm/tasks/InstallRpm.groovy
@@ -17,7 +17,7 @@ class InstallRpm extends AbstractRpm {
                 }
             }
             session(remote) {
-                executeSudo "rpm -Uvh ${apgRpmDeployConfigExt.remoteDestFolder}/${apgRpmDeployConfigExt.rpmFileName}", pty: true
+                executeSudo "f=\$(ls -t1 ${apgRpmDeployConfigExt.remoteDestFolder}/*.rpm | head -n 1) && rpm -Uvh downloads/\$f", pty: true
                 // JHE: this probably won't stay like that, as we won't want to delete a production RPM before having archiving it. But quick fix for now for Digiflex
                 execute "rm -f ${apgRpmDeployConfigExt.remoteDestFolder}/${apgRpmDeployConfigExt.rpmFileName}", pty: true
             }

--- a/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/rpm/tasks/InstallRpm.groovy
+++ b/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/rpm/tasks/InstallRpm.groovy
@@ -8,7 +8,7 @@ class InstallRpm extends AbstractRpm {
     def doRun(Object remote, Object allowAnyHosts) {
         preConditions()
         def apgRpmDeployConfigExt = getDeployConfig()
-        if(apgRpmDeployConfigExt.rpmFileName?.trim()) {
+        if(!apgRpmDeployConfigExt.rpmFileName?.trim()) {
             project.logger.info("Latest RPM within ${apgRpmDeployConfigExt.remoteDestFolder} will be install on ${remote.getProperty('host')} using ${remote.getProperty('user')} User")
         } else {
             project.logger.info("${apgRpmDeployConfigExt.rpmFileName} will be install on ${remote.getProperty('host')} using ${remote.getProperty('user')} User")
@@ -21,7 +21,7 @@ class InstallRpm extends AbstractRpm {
                 }
             }
 
-            if(apgRpmDeployConfigExt.rpmFileName?.trim()) {
+            if(!apgRpmDeployConfigExt.rpmFileName?.trim()) {
                 session(remote) {
                     execute "f=\$(ls -t1 ${apgRpmDeployConfigExt.remoteDestFolder}/*.rpm | head -n 1) && sudo rpm -Uvh \$f", pty: true
                     // JHE: probably we want to archive the RPM before deleting it ?? To be discussed with UGE/CHE

--- a/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/rpm/tasks/InstallRpm.groovy
+++ b/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/rpm/tasks/InstallRpm.groovy
@@ -18,8 +18,8 @@ class InstallRpm extends AbstractRpm {
             }
             session(remote) {
                 execute "f=\$(ls -t1 ${apgRpmDeployConfigExt.remoteDestFolder}/*.rpm | head -n 1) && sudo rpm -Uvh \$f", pty: true
-                // JHE: this probably won't stay like that, as we won't want to delete a production RPM before having archiving it. But quick fix for now for Digiflex
-                execute "rm -f ${apgRpmDeployConfigExt.remoteDestFolder}/${apgRpmDeployConfigExt.rpmFileName}", pty: true
+                // JHE: probably we want to archive the RPM before deleting it ?? To be discussed with UGE/CHE
+                execute "f=\$(ls -t1 ${apgRpmDeployConfigExt.remoteDestFolder}/*.rpm | head -n 1) && rm -f \$f", pty: true
             }
         }
     }

--- a/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/rpm/tasks/InstallRpm.groovy
+++ b/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/rpm/tasks/InstallRpm.groovy
@@ -17,7 +17,7 @@ class InstallRpm extends AbstractRpm {
                 }
             }
             session(remote) {
-                executeSudo "f=\$(ls -t1 ${apgRpmDeployConfigExt.remoteDestFolder}/*.rpm | head -n 1) && rpm -Uvh downloads/\$f", pty: true
+                executeSudo "f=\$(ls -t1 ${apgRpmDeployConfigExt.remoteDestFolder}/*.rpm | head -n 1) && rpm -Uvh \$f", pty: true
                 // JHE: this probably won't stay like that, as we won't want to delete a production RPM before having archiving it. But quick fix for now for Digiflex
                 execute "rm -f ${apgRpmDeployConfigExt.remoteDestFolder}/${apgRpmDeployConfigExt.rpmFileName}", pty: true
             }

--- a/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/rpm/tasks/InstallRpm.groovy
+++ b/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/rpm/tasks/InstallRpm.groovy
@@ -8,7 +8,11 @@ class InstallRpm extends AbstractRpm {
     def doRun(Object remote, Object allowAnyHosts) {
         preConditions()
         def apgRpmDeployConfigExt = getDeployConfig()
-        project.logger.info("${apgRpmDeployConfigExt.rpmFileName} will be install on ${remote.getProperty('host')} using ${remote.getProperty('user')} User")
+        if(apgRpmDeployConfigExt.rpmFileName?.trim()) {
+            project.logger.info("Latest RPM within ${apgRpmDeployConfigExt.remoteDestFolder} will be install on ${remote.getProperty('host')} using ${remote.getProperty('user')} User")
+        } else {
+            project.logger.info("${apgRpmDeployConfigExt.rpmFileName} will be install on ${remote.getProperty('host')} using ${remote.getProperty('user')} User")
+        }
         project.ssh.run {
             if (apgRpmDeployConfigExt.allowAnyHosts) {
                 project.logger.info("Allowing SSH Anyhosts ")
@@ -16,10 +20,20 @@ class InstallRpm extends AbstractRpm {
                     knownHosts = allowAnyHosts
                 }
             }
-            session(remote) {
-                execute "f=\$(ls -t1 ${apgRpmDeployConfigExt.remoteDestFolder}/*.rpm | head -n 1) && sudo rpm -Uvh \$f", pty: true
-                // JHE: probably we want to archive the RPM before deleting it ?? To be discussed with UGE/CHE
-                execute "f=\$(ls -t1 ${apgRpmDeployConfigExt.remoteDestFolder}/*.rpm | head -n 1) && rm -f \$f", pty: true
+
+            if(apgRpmDeployConfigExt.rpmFileName?.trim()) {
+                session(remote) {
+                    execute "f=\$(ls -t1 ${apgRpmDeployConfigExt.remoteDestFolder}/*.rpm | head -n 1) && sudo rpm -Uvh \$f", pty: true
+                    // JHE: probably we want to archive the RPM before deleting it ?? To be discussed with UGE/CHE
+                    execute "f=\$(ls -t1 ${apgRpmDeployConfigExt.remoteDestFolder}/*.rpm | head -n 1) && rm -f \$f", pty: true
+                }
+            }
+            else {
+                session(remote) {
+                    executeSudo "rpm -Uvh ${apgRpmDeployConfigExt.remoteDestFolder}/${apgRpmDeployConfigExt.rpmFileName}", pty: true
+                    // JHE: probably we want to archive the RPM before deleting it ?? To be discussed with UGE/CHE
+                    execute "rm -f ${apgRpmDeployConfigExt.remoteDestFolder}/${apgRpmDeployConfigExt.rpmFileName}", pty: true
+                }
             }
         }
     }

--- a/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/zip/tasks/AbstractZip.groovy
+++ b/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/zip/tasks/AbstractZip.groovy
@@ -19,7 +19,6 @@ abstract class AbstractZip extends AbstractSshTask {
         Assert.notNull(apgSshConfig.userpwd, "${ApgSsh.PLUGIN_ID} requires a user password to be configured")
         Assert.notNull(apgSshConfig.destinationHost, "${ApgSsh.PLUGIN_ID} requires a destination host to be configured")
         Assert.notNull(apgZipDeployConfigExt.zipFilePath, "${ApgSsh.APG_ZIP_DEPLOY_CONFIG_EXTENSION_NAME} requires a zipFilePath to be configured")
-        Assert.notNull(apgZipDeployConfigExt.zipFileName, "${ApgSsh.APG_ZIP_DEPLOY_CONFIG_EXTENSION_NAME} requires a zipFileName to be configured")
         Assert.notNull(apgZipDeployConfigExt.remoteDeployDestFolder, "${ApgSsh.APG_ZIP_DEPLOY_CONFIG_EXTENSION_NAME} requires a remoteDeployDestFolder to be configured")
     }
 

--- a/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/zip/tasks/InstallZip.groovy
+++ b/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/zip/tasks/InstallZip.groovy
@@ -22,7 +22,7 @@ class InstallZip extends AbstractZip {
             session(remote) {
                 def uiGettingExtractedFolder = "${apgZipDeployConfigExt.remoteExtractDestFolder}/gettingExtracted_${newFolderName}"
                 execute "mkdir -p ${uiGettingExtractedFolder}"
-                execute "unzip ${apgZipDeployConfigExt.remoteDeployDestFolder}/${apgZipDeployConfigExt.zipFileName} -d ${uiGettingExtractedFolder}"
+                execute "f=\$(ls -t1 ${apgZipDeployConfigExt.remoteExtractDestFolder}/*.zip | head -n 1) && unzip \$f -d ${uiGettingExtractedFolder}"
                 execute "chmod -R 775 ${uiGettingExtractedFolder}"
                 execute "rm -f ${apgZipDeployConfigExt.remoteDeployDestFolder}/${apgZipDeployConfigExt.zipFileName}"
                 execute "mv ${uiGettingExtractedFolder}/start_it21_gui_run.bat ${apgZipDeployConfigExt.remoteExtractDestFolder}"

--- a/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/zip/tasks/InstallZip.groovy
+++ b/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/zip/tasks/InstallZip.groovy
@@ -10,7 +10,11 @@ class InstallZip extends AbstractZip {
     def doRun(Object remote, Object allowAnyHosts) {
         preConditions()
         def apgZipDeployConfigExt = getDeployConfig()
-        project.logger.info("${apgZipDeployConfigExt.zipFileName} will be install on ${remote.getProperty('host')} using ${remote.getProperty('user')} User")
+        if(apgZipDeployConfigExt.zipFileName?.trim()) {
+            project.logger.info("Latest ZIP within ${apgZipDeployConfigExt.remoteExtractDestFolder} will be install on ${remote.getProperty('host')} using ${remote.getProperty('user')} User")
+        } else {
+            project.logger.info("${apgZipDeployConfigExt.remoteDeployDestFolder}/${apgZipDeployConfigExt.zipFileName} will be install on ${remote.getProperty('host')} using ${remote.getProperty('user')} User")
+        }
         def newFolderName = guiExtractedFolderName()
         project.ssh.run {
             if (apgZipDeployConfigExt.allowAnyHosts) {
@@ -22,7 +26,12 @@ class InstallZip extends AbstractZip {
             session(remote) {
                 def uiGettingExtractedFolder = "${apgZipDeployConfigExt.remoteExtractDestFolder}/gettingExtracted_${newFolderName}"
                 execute "mkdir -p ${uiGettingExtractedFolder}"
-                execute "f=\$(ls -t1 ${apgZipDeployConfigExt.remoteExtractDestFolder}/*.zip | head -n 1) && unzip \$f -d ${uiGettingExtractedFolder}"
+                if(apgZipDeployConfigExt.zipFileName?.trim()) {
+                    execute "f=\$(ls -t1 ${apgZipDeployConfigExt.remoteDeployDestFolder}/*.zip | head -n 1) && unzip \$f -d ${uiGettingExtractedFolder}"
+                }
+                else {
+                    execute "unzip ${apgZipDeployConfigExt.remoteDeployDestFolder}/${apgZipDeployConfigExt.zipFileName} -d ${uiGettingExtractedFolder}"
+                }
                 execute "chmod -R 775 ${uiGettingExtractedFolder}"
                 execute "rm -f ${apgZipDeployConfigExt.remoteDeployDestFolder}/${apgZipDeployConfigExt.zipFileName}"
                 execute "mv ${uiGettingExtractedFolder}/start_it21_gui_run.bat ${apgZipDeployConfigExt.remoteExtractDestFolder}"

--- a/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/zip/tasks/InstallZip.groovy
+++ b/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/zip/tasks/InstallZip.groovy
@@ -10,7 +10,7 @@ class InstallZip extends AbstractZip {
     def doRun(Object remote, Object allowAnyHosts) {
         preConditions()
         def apgZipDeployConfigExt = getDeployConfig()
-        if(apgZipDeployConfigExt.zipFileName?.trim()) {
+        if(!apgZipDeployConfigExt.zipFileName?.trim()) {
             project.logger.info("Latest ZIP within ${apgZipDeployConfigExt.remoteExtractDestFolder} will be install on ${remote.getProperty('host')} using ${remote.getProperty('user')} User")
         } else {
             project.logger.info("${apgZipDeployConfigExt.remoteDeployDestFolder}/${apgZipDeployConfigExt.zipFileName} will be install on ${remote.getProperty('host')} using ${remote.getProperty('user')} User")
@@ -26,7 +26,7 @@ class InstallZip extends AbstractZip {
             session(remote) {
                 def uiGettingExtractedFolder = "${apgZipDeployConfigExt.remoteExtractDestFolder}/gettingExtracted_${newFolderName}"
                 execute "mkdir -p ${uiGettingExtractedFolder}"
-                if(apgZipDeployConfigExt.zipFileName?.trim()) {
+                if(!apgZipDeployConfigExt.zipFileName?.trim()) {
                     execute "f=\$(ls -t1 ${apgZipDeployConfigExt.remoteDeployDestFolder}/*.zip | head -n 1) && unzip \$f -d ${uiGettingExtractedFolder}"
                 }
                 else {


### PR DESCRIPTION
Providing the possibility to install an RPM/ZIP, either by providing the exact file name to be installed, or by taking the most recent file from within a specified folder on remote target.

DSL usage will be:

```
apgRpmDeployConfig {
	rpmFilePath "${buildDir}/distributions/"
	remoteDestFolder "${project.ext.downloadDir}/${apgPackage.name}/${installTarget}"
}
```

or

```
apgRpmDeployConfig {
	rpmFilePath "${buildDir}/distributions/"
        rpmFileName "<specifyNameHere>"
	remoteDestFolder "${project.ext.downloadDir}/${apgPackage.name}/${installTarget}"
}
```

Note that the DSL without specifying "rpmFileName" doesn't impact the assemble/deploy part, because there the name is applied from our version-resolver (cool !! ;) )