### PR TITLE
Naming Standard from ApgCommonPackageExtension

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -44,6 +44,7 @@
       <module name="apg-gradle-plugins.zip-ssh-deployer.integrationTest" target="1.8" />
       <module name="apg-gradle-plugins.zip-ssh-deployer.main" target="1.8" />
       <module name="apg-gradle-plugins.zip-ssh-deployer.test" target="1.8" />
+      <module name="dm-bom" target="1.5" />
       <module name="docker-sshd-compose.main" target="1.8" />
       <module name="docker-sshd-compose.test" target="1.8" />
       <module name="it21-ui-bundle.it21-ui-dm-version-manager.main" target="1.8" />
@@ -69,6 +70,10 @@
       <module name="jenkins-pipeline-tests.test" target="1.8" />
       <module name="jenkins-pipeline.main" target="1.8" />
       <module name="jenkins-pipeline.test" target="1.8" />
+      <module name="parent" target="1.5" />
+      <module name="parent-pom" target="8" />
+      <module name="testapp-module" target="8" />
+      <module name="testapp-service" target="8" />
       <module name="testapp-service-kotlin.main" target="1.8" />
       <module name="testapp-service-kotlin.test" target="1.8" />
     </bytecodeTargetLevel>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -12,7 +12,6 @@
             <option value="$PROJECT_DIR$/integration/digiflex" />
           </set>
         </option>
-        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
       <GradleProjectSettings>
         <option name="delegatedBuild" value="true" />
@@ -26,7 +25,6 @@
             <option value="$PROJECT_DIR$/integration/digiflex/digiflex-it21-ui-pkg" />
           </set>
         </option>
-        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
       <GradleProjectSettings>
         <option name="distributionType" value="DEFAULT_WRAPPED" />
@@ -37,7 +35,6 @@
             <option value="$PROJECT_DIR$/integration/digiflex/digiflex-jadas-pkg" />
           </set>
         </option>
-        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
       <GradleProjectSettings>
         <option name="delegatedBuild" value="true" />
@@ -51,7 +48,6 @@
             <option value="$PROJECT_DIR$/integration/digiflex/digiflex-web-it21-pkg" />
           </set>
         </option>
-        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
       <GradleProjectSettings>
         <option name="distributionType" value="DEFAULT_WRAPPED" />
@@ -62,7 +58,6 @@
             <option value="$PROJECT_DIR$/integration/modules/testapp-pkg" />
           </set>
         </option>
-        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
       <GradleProjectSettings>
         <option name="delegatedBuild" value="true" />
@@ -76,18 +71,14 @@
             <option value="$PROJECT_DIR$/plugins" />
             <option value="$PROJECT_DIR$/plugins/common-repo" />
             <option value="$PROJECT_DIR$/plugins/common-test" />
-            <option value="$PROJECT_DIR$/plugins/docker-client" />
             <option value="$PROJECT_DIR$/plugins/generic-publish" />
             <option value="$PROJECT_DIR$/plugins/gradle-common" />
-            <option value="$PROJECT_DIR$/plugins/maven-publish" />
             <option value="$PROJECT_DIR$/plugins/packaging-tasks" />
-            <option value="$PROJECT_DIR$/plugins/repo-config" />
             <option value="$PROJECT_DIR$/plugins/revision-manager" />
             <option value="$PROJECT_DIR$/plugins/ssh-tasks" />
             <option value="$PROJECT_DIR$/plugins/version-manager" />
           </set>
         </option>
-        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -81,5 +81,10 @@
       <option name="name" value="public-snapshots" />
       <option name="url" value="https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga/public-snapshots" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga//repo" />
+    </remote-repository>
   </component>
 </project>

--- a/.idea/kotlinScripting.xml
+++ b/.idea/kotlinScripting.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinScriptingSettings">
-    <option name="isAutoReloadEnabled" value="true" />
     <option name="suppressDefinitionsCheck" value="true" />
     <scriptDefinition className="org.jetbrains.kotlin.idea.core.script.GradleScriptDefinitionsContributor.ErrorGradleScriptDefinition.LegacyDefinition" definitionName="Default Kotlin Gradle Script">
       <order>2</order>
@@ -9,6 +8,10 @@
     </scriptDefinition>
     <scriptDefinition className="org.jetbrains.kotlin.idea.core.script.StandardIdeScriptDefinition" definitionName="Kotlin Script">
       <order>3</order>
+    </scriptDefinition>
+    <scriptDefinition className="org.jetbrains.kotlin.scripting.resolve.KotlinScriptDefinitionFromAnnotatedTemplate" definitionName="KotlinBuildScript">
+      <order>2147483647</order>
+      <autoReloadConfigurations>true</autoReloadConfigurations>
     </scriptDefinition>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -27,11 +27,6 @@
         <option value="$USER_HOME$/Projects/testapp-parent-pom/pom.xml" />
         <option value="$PROJECT_DIR$/integration/testapp-bom/pom.xml" />
         <option value="$PROJECT_DIR$/integration/testapp-parentpom/pom.xml" />
-        <option value="$PROJECT_DIR$/integration/modules/pom.xml" />
-        <option value="$PROJECT_DIR$/integration/modules/testapp-bom/pom.xml" />
-        <option value="$PROJECT_DIR$/integration/modules/testapp-parentpom/pom.xml" />
-        <option value="$PROJECT_DIR$/integration/modules/testapp-module/pom.xml" />
-        <option value="$PROJECT_DIR$/integration/modules/testapp-service/pom.xml" />
       </list>
     </option>
     <option name="ignoredFiles">

--- a/plugins/gradle-common/common-plugin.gradle
+++ b/plugins/gradle-common/common-plugin.gradle
@@ -14,7 +14,7 @@ apply plugin: 'eclipse'
 apply plugin: nu.studer.gradle.credentials.CredentialsPlugin
 
 group = 'com.apgsga.gradle'
-version = '2.3-SNAPSHOT'
+version = '2.4-SNAPSHOT'
 
 
 def devUser = project.credentials.devUser

--- a/plugins/packaging-tasks/src/main/groovy/com/apgsga/packaging/rpm/tasks/OsPackageConfigureTask.groovy
+++ b/plugins/packaging-tasks/src/main/groovy/com/apgsga/packaging/rpm/tasks/OsPackageConfigureTask.groovy
@@ -90,7 +90,7 @@ class OsPackageConfigureTask extends DefaultTask {
 		}
 		osPackageExtention.from("$project.buildDir/app-pkg/app/conf/app",copySpec)
 		Task buildRpmTask = project.tasks.findByName("buildRpm")
-		buildRpmTask.archiveName = apgRpmPackage.archiveName
+		buildRpmTask.archiveName = apgRpmPackage.archiveName  + ".noarch.rpm"
 		buildRpmTask.directory("${apgRpmPackage.targetServiceDataDir}", 0775 )
 		buildRpmTask.directory("${apgRpmPackage.targetServiceDataDir}/log", 0775 )
 	}

--- a/plugins/packaging-tasks/src/main/java/com/apgsga/packaging/extensions/ApgCommonPackageExtension.java
+++ b/plugins/packaging-tasks/src/main/java/com/apgsga/packaging/extensions/ApgCommonPackageExtension.java
@@ -273,7 +273,7 @@ public class ApgCommonPackageExtension {
 
 
     public String getArchiveName() {
-        return getTargetServiceName() + "-" + getVersion() + "-" + getReleaseNr() + ".noarch.rpm";
+        return getTargetServiceName() + "-" + getVersion() + "-" + getReleaseNr();
     }
 
     @Override

--- a/plugins/ssh-tasks/build.gradle
+++ b/plugins/ssh-tasks/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     //           BUT: in worse case, testCompile should be enough, doesn't seem to be the case
     //                best case, this dependency should be resolved within common-test or within gradle-common (functionalTest.gradle)
     compile project(':common-repo')
+    compile project(':packaging-tasks')
     compile group: 'org.springframework', name: 'spring-core', version: '5.2.1.RELEASE'
     compile group: "org.hidetake", name: 'gradle-ssh-plugin', version: '2.10.1'
 }

--- a/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/rpm/tasks/DeployRpm.groovy
+++ b/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/rpm/tasks/DeployRpm.groovy
@@ -1,5 +1,6 @@
 package com.apgsga.ssh.rpm.tasks
 
+import com.apgsga.packaging.extensions.ApgCommonPackageExtension
 import com.apgsga.ssh.general.tasks.SshPutTask
 import com.apgsga.ssh.plugins.ApgSsh
 
@@ -13,9 +14,10 @@ class DeployRpm extends AbstractRpm {
     @Override
     def doRun(Object remote, Object allowAnyHosts) {
         def apgRpmDeployConfigExt = project.extensions."${ApgSsh.APG_RPM_DEPLOY_CONFIG_EXTENSION_NAME}"
+        def apgPkgCommon = project.extensions.getByType(ApgCommonPackageExtension.class)
         preConditions()
         SshPutTask put = project.tasks.findByName(SshPutTask.TASK_NAME)
-        put.from = new File("${apgRpmDeployConfigExt.rpmFilePath}" + File.separator + apgRpmDeployConfigExt.rpmFileName)
+        put.from = new File("${apgRpmDeployConfigExt.rpmFilePath}" + File.separator + apgPkgCommon.archiveName + ".noarch.rpm" )
         put.into = "${apgRpmDeployConfigExt.remoteDestFolder}"
         put.doRun(remote,allowAnyHosts)
     }

--- a/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
+++ b/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
@@ -57,12 +57,6 @@ open class VersionResolutionExtension(val project: Project, private val revision
             if (_revisionManger == null) {
                 _revisionManger = revisionManagerBuilder.revisionRootPath(revisionRootPath
                         ?: project.gradle.gradleUserHomeDir.absolutePath).cloneTargetPath(cloneTargetPath).algorithm(algorithm).build()
-
-                // JHE (14.07.2020): we eventually want to do this only for CLONED scenario, not 100% sure yet.
-                val pkgExt = project.extensions.getByType(ApgCommonPackageExtension::class.java)
-                pkgExt.releaseNr = releasedNr
-                val rpmDeployExt = project.extensions.getByType(ApgRpmDeployConfig::class.java)
-                rpmDeployExt.rpmFileName = pkgExt.archiveName
             }
             return _revisionManger as RevisionManager
         }
@@ -185,6 +179,10 @@ open class VersionResolutionExtension(val project: Project, private val revision
                 .bomArtifact("${bomGroupId}:${bomArtifactId}:${bomLastRevision?.let { version(it) }}")
                 .recursive(true))
         return compositeResolverBuilder.build(project)
+    }
+
+    fun version(): String {
+        return version(bomBaseVersion,bomLastRevision)
     }
 
 

--- a/plugins/version-manager/src/main/kotlin/com/apgsga/maven/impl/bom/MavenBomManagerDefault.kt
+++ b/plugins/version-manager/src/main/kotlin/com/apgsga/maven/impl/bom/MavenBomManagerDefault.kt
@@ -3,7 +3,6 @@ package com.apgsga.maven.impl.bom
 import com.apgsga.maven.BomLoader
 import com.apgsga.maven.LoggerDelegate
 import com.apgsga.maven.MavenBomManager
-import com.apgsga.maven.dm.ext.version
 import org.apache.maven.model.Dependency
 import org.apache.maven.model.Model
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader


### PR DESCRIPTION
@apgsga-jhe This is a quick one. 

For the com.apgsga.ssh.rpm.tasks.DeployRpm Task the package name is taken from ApgCommonPackageExtension
The Task itself is responsible for the suffix. 

I also bumped to Version of the Plugins to 2.4-SNAPSHOT 

I will merge this one almost immediately. 
