### PR TITLE
Removed circular dependency version-manager and packaging-tasks

### DIFF
--- a/plugins/gradle-common/common-plugin.gradle
+++ b/plugins/gradle-common/common-plugin.gradle
@@ -14,7 +14,7 @@ apply plugin: 'eclipse'
 apply plugin: nu.studer.gradle.credentials.CredentialsPlugin
 
 group = 'com.apgsga.gradle'
-version = '2.4-SNAPSHOT'
+version = '2.5-SNAPSHOT'
 
 
 def devUser = project.credentials.devUser

--- a/plugins/version-manager/build.gradle.kts
+++ b/plugins/version-manager/build.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     compile(project(":common-repo"))
     compile(project(":generic-publish"))
     compile(project(":revision-manager"))
-    compile(project(":packaging-tasks"))
     compile(project(":ssh-tasks"))
     compile("org.slf4j:slf4j-api:1.7.25")
     integrationTestRuntimeOnly("org.slf4j:slf4j-simple:1.7.29")


### PR DESCRIPTION
@apgsga-jhe  This is fairly straight forward: 
Basically the 
`    var configurationName: String? = null
    var installTarget: String? = null
    var serviceName: String? = null`
are now kept redundant between apgVersionResolver and apgPackage  as a intermediate step. 

I have adopted and commited testapp-pkg and test-pkg-2 

I have bumped to Plugin Version to 2.5-SNAPSHOT