### PR TITLE
ApgCommonPackageExtension version from VersionResolution

### DIFF
--- a/plugins/gradle-common/common-plugin.gradle
+++ b/plugins/gradle-common/common-plugin.gradle
@@ -14,7 +14,7 @@ apply plugin: 'eclipse'
 apply plugin: nu.studer.gradle.credentials.CredentialsPlugin
 
 group = 'com.apgsga.gradle'
-version = '2.5-SNAPSHOT'
+version = '2.6-SNAPSHOT'
 
 
 def devUser = project.credentials.devUser

--- a/plugins/packaging-tasks/build.gradle
+++ b/plugins/packaging-tasks/build.gradle
@@ -31,4 +31,5 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '20.0'
     compile group: 'com.netflix.nebula', name: 'gradle-ospackage-plugin', version: '5.3.5'
     compile project(':common-repo')
+    compile project(':version-manager')
 }

--- a/plugins/packaging-tasks/src/functionalTest/groovy/com/apgsga/packaging/it21gui/tasks/test/ZipPackageTaskTests.groovy
+++ b/plugins/packaging-tasks/src/functionalTest/groovy/com/apgsga/packaging/it21gui/tasks/test/ZipPackageTaskTests.groovy
@@ -2,11 +2,11 @@ package com.apgsga.packaging.it21gui.tasks.test
 
 import com.apgsga.gradle.test.utils.AbstractSpecification
 import com.apgsga.packaging.plugins.ApgGuiPackagePlugin
+import spock.lang.Ignore
 
 import static groovy.io.FileType.FILES
 
 class ZipPackageTaskTests extends AbstractSpecification  {
-
     def "archivePackage works"() {
         given:
         buildFile << """
@@ -18,12 +18,18 @@ class ZipPackageTaskTests extends AbstractSpecification  {
             
             apply from : "${gradleHomeDirPath.replace("\\","/")}/common/portnr.gradle"
 
+			apgVersionResolver {
+				configurationName = "testRuntime"
+				serviceName = "testuiapp"
+				installTarget = 'CHEI212'
+				bomBaseVersion = '2.1'
+			}
 			// The guava dependency is only for testing purposes, consider to be likely found in mavenCentral()
 			apgPackage {
 				name ="testuiapp"
 				configurationName = "testRuntime"
 				dependencies = ["com.google.guava:guava:+"]
-				version = "2.1-SNAPSHOT"
+				installTarget = 'CHEI212'
 			 }
 			 apgPackage.log()
  			 

--- a/plugins/packaging-tasks/src/functionalTest/groovy/com/apgsga/packaging/rpm/tasks/test/BuildRpmTaskTests.groovy
+++ b/plugins/packaging-tasks/src/functionalTest/groovy/com/apgsga/packaging/rpm/tasks/test/BuildRpmTaskTests.groovy
@@ -21,6 +21,13 @@ class BuildRpmTaskTests extends AbstractSpecification {
             plugins {
                 id '${ApgRpmPackagePlugin.PLUGIN_ID}'
             }
+            
+        apgVersionResolver {
+		    configurationName = "testRuntime"
+				serviceName = "testapp"
+				installTarget = 'CHTX211'
+				bomBaseVersion = '1.0'
+		}
 
 		// The guava dependency is only for testing purposes, consider to be likely found in mavenCentral()
         apgPackage {
@@ -28,7 +35,6 @@ class BuildRpmTaskTests extends AbstractSpecification {
 		    dependencies = ["com.google.guava:guava:+"]
             installTarget = "CHTX211"
 			mainProgramName  = "com.apgsga.test.SomeMain"
-			version = "1.0"
 		    releaseNr = "1"
          }
         """

--- a/plugins/packaging-tasks/src/main/java/com/apgsga/packaging/extensions/ApgCommonPackageExtension.java
+++ b/plugins/packaging-tasks/src/main/java/com/apgsga/packaging/extensions/ApgCommonPackageExtension.java
@@ -1,5 +1,7 @@
 package com.apgsga.packaging.extensions;
 
+import com.apgsga.maven.dm.ext.VersionResolutionExtension;
+import com.apgsga.maven.dm.ext.VersionResolutionKt;
 import com.apgsga.packaging.service.pkg.extension.PortnrConvention;
 import org.gradle.api.Project;
 
@@ -13,7 +15,7 @@ public class ApgCommonPackageExtension {
 	private static final String RESOURCES_PATH_DEFAULT = "resources";
 	private static final String APG_OPSDEFAULT = "apg_ops";
 	private static final String RELEASENR_DEFAULT = "1";
-	private static final String VERSION_DEFAULT = "0.1";
+	private static final String VERSION_DEFAULT = "NOP";
 	private static final String JAVADIST_DEFAULT = "jdk-8u191-linux-x64.tar.gz";
 	private static final String JAVADIR_DEFAULT = "jdk1.8.0_191";
 	private static final boolean WEBEMMEDED_DEFAULT = false;
@@ -48,8 +50,7 @@ public class ApgCommonPackageExtension {
 	private String javaDir = JAVADIR_DEFAULT; 
 	private String javaDist = JAVADIST_DEFAULT; 
 	private String distRepoUrl = DIST_REPO_URL;
-	private String version = VERSION_DEFAULT;
-	private String releaseNr = RELEASENR_DEFAULT; 
+	private String releaseNr = RELEASENR_DEFAULT;
 	private String opsUserGroup = APG_OPSDEFAULT; 
 	private String resourcesPath = RESOURCES_PATH_DEFAULT;
     private String javaOpts = JAVAOPTS_DEFAULT;
@@ -187,11 +188,9 @@ public class ApgCommonPackageExtension {
     }
 
     public String getVersion() {
-        return version;
-    }
-
-    public void setVersion(String version) {
-        this.version = version;
+        VersionResolutionExtension ext = project.getExtensions().getByType(VersionResolutionExtension.class);
+        String version = ext.version();
+        return version == null ? VERSION_DEFAULT : version;
     }
 
     public String getReleaseNr() {
@@ -295,7 +294,6 @@ public class ApgCommonPackageExtension {
                 ", javaDir='" + javaDir + '\'' +
                 ", javaDist='" + javaDist + '\'' +
                 ", distRepoUrl='" + distRepoUrl + '\'' +
-                ", version='" + version + '\'' +
                 ", releaseNr='" + releaseNr + '\'' +
                 ", opsUserGroup='" + opsUserGroup + '\'' +
                 ", resourcesPath='" + resourcesPath + '\'' +

--- a/plugins/packaging-tasks/src/main/java/com/apgsga/packaging/plugins/ApgCommonPackagePlugin.java
+++ b/plugins/packaging-tasks/src/main/java/com/apgsga/packaging/plugins/ApgCommonPackagePlugin.java
@@ -1,5 +1,6 @@
 package com.apgsga.packaging.plugins;
 
+import com.apgsga.maven.dm.plugin.VersionResolutionPlugin;
 import com.apgsga.packaging.common.task.BinariesCopyTask;
 import com.apgsga.packaging.common.task.ConfigureDepsTask;
 import com.apgsga.packaging.extensions.ApgCommonPackageExtension;
@@ -26,6 +27,7 @@ public class ApgCommonPackagePlugin implements Plugin<Project> {
         final PluginContainer plugins = project.getPlugins();
         ext.create(ApgCommonPackageExtension.EXT_NAME, ApgCommonPackageExtension.class, project);
         plugins.apply(ApgCommonRepoPlugin.class);
+        plugins.apply(VersionResolutionPlugin.class);
         TaskContainer tasks = project.getTasks();
         TaskProvider<BinariesCopyTask> binariesCopyTask = tasks.register("copyAppBinaries", BinariesCopyTask.class);
         TaskProvider<ConfigureDepsTask> configureDeps = tasks.register("configureDeps", ConfigureDepsTask.class);

--- a/plugins/version-manager/build.gradle.kts
+++ b/plugins/version-manager/build.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     compile(project(":common-repo"))
     compile(project(":generic-publish"))
     compile(project(":revision-manager"))
-    compile(project(":ssh-tasks"))
     compile("org.slf4j:slf4j-api:1.7.25")
     integrationTestRuntimeOnly("org.slf4j:slf4j-simple:1.7.29")
 

--- a/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
+++ b/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
@@ -27,9 +27,9 @@ fun version(baseVersion: String?, revision: String?): String {
 }
 
 open class VersionResolutionExtension(val project: Project, private val revisionManagerBuilder: RevisionManagerBuilder) {
-    var configurationName: String? = null
-    var installTarget: String? = null
-    var serviceName: String? = null
+    var configurationName: String = "null"
+    var installTarget: String = "null"
+    var serviceName: String = "null"
     var bomArtifactId: String? = null
     var bomGroupId: String? = null
     var bomBaseVersion: String? = null

--- a/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/plugin/VersionResolutionPlugin.kt
+++ b/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/plugin/VersionResolutionPlugin.kt
@@ -1,10 +1,8 @@
 package com.apgsga.maven.dm.plugin
 
 import com.apgsga.maven.dm.ext.VersionResolutionExtension
-import com.apgsga.packaging.plugins.ApgCommonPackagePlugin
 import com.apgsga.revision.manager.domain.RevisionManagerBuilder
 import com.apgsga.common.repo.plugin.ApgCommonRepoPlugin
-import com.apgsga.packaging.extensions.ApgCommonPackageExtension
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -16,7 +14,6 @@ open class VersionResolutionPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.plugins.apply(ApgCommonRepoPlugin::class.java)
         project.plugins.apply(MavenPublishPlugin::class.java)
-        project.plugins.apply(ApgCommonPackagePlugin::class.java)
         val revisionManagerBuilder = RevisionManagerBuilder.create()
         val extension =  project.extensions.create("apgVersionResolver", VersionResolutionExtension::class.java, project, revisionManagerBuilder)
         project.afterEvaluate {


### PR DESCRIPTION
@apgsga-jhe ApgCommonPackageExtension now takes the version , which is used in getArchiveName as Namingconvetion, from the VersionResolutionExtension. 

So we have a Naming like: 

`testapp-pkg-2  ls -ls build/distributions/                                                                                                                                                    2684ms Do  3 Sep 14:13:59 2020
total 33168
33168 -rw-r--r--  1 chhex  staff  16917796  3 Sep 14:13 apg-calcuservice-CHEI212-1.0-SNAPSHOT-1.noarch.rpm`

for a SNAPSHOT Build. In case of a PATCH Build a Revisionnummer will be in place of SNAPSHOT.

TODO: Add to Patch nummer to the Naming Convention = Align the naming convention generally to what is today in place for the jadas rpm. 
I will create a ticket for this.  And address the ticket, after taking the Patchfile into account for ApgVersionResolver.

Later this afternoon i will merge, to continue with the next steps:

1.  Publish to correct repo of the new Bom 
2. Take into account the PatchFile for the Versionresolver
3. Patchnumber in Naming Convention 
4. Updateing a BOM: Take into account the maven coordinates of the artifact to be updated

1, 2 with 3 ,  4 will each a seperate Pull request. 

Please review and feedback. Also look at the already merged Pull requests. 

I bumped the Version with this pull request tp 2.6-SNAPSHOT