### PR TITLE
Publish new Bom to maven Repository

### DIFF
--- a/plugins/gradle-common/common-plugin.gradle
+++ b/plugins/gradle-common/common-plugin.gradle
@@ -14,7 +14,7 @@ apply plugin: 'eclipse'
 apply plugin: nu.studer.gradle.credentials.CredentialsPlugin
 
 group = 'com.apgsga.gradle'
-version = '2.6-SNAPSHOT'
+version = '2.7-SNAPSHOT'
 
 
 def devUser = project.credentials.devUser

--- a/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerPatchImpl.groovy
+++ b/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerPatchImpl.groovy
@@ -12,9 +12,9 @@ class RevisionManagerPatchImpl implements RevisionManager {
 
     @Override
     String nextRevision() {
-        def currentRev =revisionPersistence.currentRevision()
+        def currentRev  =revisionPersistence.currentRevision() as Integer
         currentRev++
-        revisionPersistence.save(currentRev)
+        revisionPersistence.save(currentRev as String)
         return currentRev
     }
 

--- a/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
+++ b/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
@@ -60,6 +60,7 @@ open class VersionResolutionExtension(val project: Project, private val revision
     private val bomNextRevision: String
         get() {
             if (_bomNextRevision == null) {
+                _bomLastRevision = revisionManger.lastRevision(serviceName, installTarget)
                 _bomNextRevision = revisionManger.nextRevision().toString()
             }
             return _bomNextRevision as String
@@ -103,6 +104,7 @@ open class VersionResolutionExtension(val project: Project, private val revision
     }
 
     private fun generateBomXml(publication: MavenPublication) {
+
         publication.artifactId = bomArtifactId
         publication.groupId = bomGroupId
         publication.version = version(bomNextRevision)
@@ -135,6 +137,7 @@ open class VersionResolutionExtension(val project: Project, private val revision
         assert(bomGroupId != null) { "bomGroupId should not be null" }
         assert(bomBaseVersion != null) { "bomBaseVersion should not be null" }
         assert(bomLastRevision != null) { "lastRevision should not be null" }
+        project.logger.info("BuildVersionResolver with $bomArtifactId, $bomGroupId, $bomBaseVersion and $bomLastRevision")
         configurationName?.let { configureConfiguration(it) }
         val compositeResolverBuilder = CompositeVersionResolverBuilder()
         project.logger.info("Creating Dependency configuration")


### PR DESCRIPTION
@apgsga-jhe  This one should also be ready to merge. 
I changed the publishing of  testapp-pkg  and testapp-pkg-2 to 

`publishing {
	publications {
		bom(MavenPublication) {
			apgVersionResolver.generateBom { }
		}
	}
	repositories {
		mavenLocal()
	}
}`

And did successive 

`/gradlew publish -PinstallTarget=CHEI212  --stacktrace --info`

for the two services.  

The bom's and revision file look good. 

Feel free to review the changes. 

Next steps for Thursday:

1. Test against our Remote Repos
2. Take into account the PatchFile for the Versionresolver
3. Patchnumber in Naming Convention
4. Updateing a BOM: Take into account the maven coordinates of the artifact to be updated
