### PR TITLE
IT-36306 / provide a minimal IT21-UI to test Gradle-Plugin

### DIFF
--- a/plugins/gradle-common/common-plugin.gradle
+++ b/plugins/gradle-common/common-plugin.gradle
@@ -14,7 +14,7 @@ apply plugin: 'eclipse'
 apply plugin: nu.studer.gradle.credentials.CredentialsPlugin
 
 group = 'com.apgsga.gradle'
-version = '2.9-SNAPSHOT'
+version = '2.10-SNAPSHOT'
 
 
 def devUser = project.credentials.devUser

--- a/plugins/packaging-tasks/src/main/groovy/com/apgsga/packaging/gui/actions/GuiZipPackageAction.groovy
+++ b/plugins/packaging-tasks/src/main/groovy/com/apgsga/packaging/gui/actions/GuiZipPackageAction.groovy
@@ -1,5 +1,6 @@
 package com.apgsga.packaging.gui.actions
 
+import com.apgsga.packaging.extensions.ApgCommonPackageExtension
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.tasks.bundling.Zip
@@ -14,13 +15,13 @@ class GuiZipPackageAction implements Action<Zip> {
 
 	@Override
     void execute(Zip zip) {
-		def ex = project.extensions.apgPackage
+		def ex = project.extensions.getByType(ApgCommonPackageExtension.class)
 		zip.from("${project.buildDir}/${ex.name}")
 		// JHE (10.06.2020): Not 100% sure, but probably we'll want to ZIP without the parent root folder, basically only the content.
 		//zip.into("${ex.name}")
 		// TODO (che, 1.10 ) Verify 
 		zip.destinationDir = new File("${project.buildDir}/distributions")
 		// TODO (che, 23.10) : Is this enough for Version?
-		zip.archiveName = "${ex.name}-${ex.version}.zip"
+		zip.archiveName = "${ex.archiveName}.zip"
 	}
 }

--- a/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/zip/tasks/DeployZip.groovy
+++ b/plugins/ssh-tasks/src/main/groovy/com/apgsga/ssh/zip/tasks/DeployZip.groovy
@@ -1,9 +1,7 @@
 package com.apgsga.ssh.zip.tasks
 
+import com.apgsga.packaging.extensions.ApgCommonPackageExtension
 import com.apgsga.ssh.general.tasks.SshPutTask
-
-// JHE (17.03.2020): Not sure we want to keep this task, one could simply directly call SshPutTask.
-//                   However, we might want to deployRpm somewhere else in the future? Might be good to keep this "wrapper"
 
 class DeployZip extends AbstractZip {
 
@@ -13,9 +11,10 @@ class DeployZip extends AbstractZip {
     def doRun(Object remote, Object allowAnyHosts) {
         preConditions()
         def apgZipDeployConfigExt = getDeployConfig()
+        def apgPkgCommon = project.extensions.getByType(ApgCommonPackageExtension.class)
         project.logger.info("${apgZipDeployConfigExt.zipFileName} will be deploy on ${remote.getProperty('host')} using ${remote.getProperty('user')} User")
         SshPutTask put = project.tasks.findByName(SshPutTask.TASK_NAME)
-        put.from = new File("${apgZipDeployConfigExt.zipFilePath}" + File.separator + apgZipDeployConfigExt.zipFileName)
+        put.from = new File("${apgZipDeployConfigExt.zipFilePath}" + File.separator + apgPkgCommon.archiveName + ".zip")
         put.into = "${apgZipDeployConfigExt.remoteDeployDestFolder}"
         put.doRun(remote,allowAnyHosts)
     }


### PR DESCRIPTION
Hi @chhex ,
Here a quick one which I'll merge today or tomorrow.
Nothing big, I aligned the way we're creating the GUI zip file name withe the way we do it for RPM. That way, buildZip and deployZip doesn't have to explicitely provide the ZIP file name, like we had until now. Basically, deployZip will then be configured with:

```
apgZipDeployConfig {
    zipFilePath "./build/distributions"
    remoteDeployDestFolder project.ext.downloadDir
    remoteExtractDestFolder project.ext.installDir
}
```

(before the zipFileName was necessary ...)

Also, I bumped the version of the plugins up, in case it has any side effect ...

Maybe I'll submit other small pull requests for IT-36306 .... but probably not with big changes.