### PR TITLE
More Logging for RevisionManager

### DIFF
--- a/plugins/gradle.properties
+++ b/plugins/gradle.properties
@@ -1,2 +1,2 @@
-publishVersion=2.17-SNAPSHOT
+publishVersion=2.18-SNAPSHOT
 publishGroup=com.apgsga.gradle

--- a/plugins/revision-manager/build.gradle
+++ b/plugins/revision-manager/build.gradle
@@ -16,6 +16,7 @@ sourceSets {
 dependencies {
     api platform(project(':platform'))
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+    implementation("org.slf4j:slf4j-api")
     implementation group: 'org.codehaus.groovy', name: 'groovy-all'
     testImplementation ("org.spockframework:spock-core")
 }

--- a/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerBuilder.groovy
+++ b/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerBuilder.groovy
@@ -2,8 +2,13 @@ package com.apgsga.revision.manager.domain
 
 import com.apgsga.revision.manager.persistence.RevisionBeanBackedPersistence
 import com.apgsga.revision.manager.persistence.RevisionPersistence
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
 
 class RevisionManagerBuilder {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(RevisionManagerBuilder.class)
 
     // TODO JHE: Shouldn't we deal with the history file as well ?
     private static String REVISION_FILENAME = "Revisions.json"
@@ -32,13 +37,15 @@ class RevisionManagerBuilder {
     }
 
     private RevisionManager buildCloneRevisionManager() {
+        LOGGER.info("RevisionManagerBuilder: building a Clone Revision Manager with target: ${cloneTargetPath}")
         def revPersistence = getRevisionPersistence()
         revPersistence.cloneRevisionsJson(cloneTargetPath)
         revisionRootPath = cloneTargetPath
-        new RevisionManagerClonedImpl(revPersistence)
+        new RevisionManagerClonedImpl(new RevisionManagerPatchImpl(revPersistence))
     }
 
     private RevisionManager buildPatchRevisionManager() {
+        LOGGER.info("RevisionManagerBuilder: building a Patch Revision Manager with Revision Root path: ${revisionRootPath}")
         new RevisionManagerPatchImpl(getRevisionPersistence())
     }
 
@@ -47,12 +54,12 @@ class RevisionManagerBuilder {
         File revisionFileRoot = new File(revisionRootPath)
         validate(revisionFileRoot.exists(), "Parent Directory ${revisionRootPath} of ${REVISION_FILENAME} must exist")
         validate(revisionFileRoot.isDirectory(), "Parent Path ${revisionRootPath} of ${REVISION_FILENAME}  must be directory")
-        println("Building Revision Manager with : ${this.toString()}")
+        LOGGER.info("RevisionManagerBuilder: building Bean backed Persitistence Revision Manager with : ${this.toString()}")
         return new RevisionBeanBackedPersistence(revisionFileRoot)
     }
 
     private static RevisionManager buildSnapshotRevisionManager() {
-        println("Building Snapshot Revision Manager")
+        LOGGER.info("RevisionManagerBuilder: building Snapshot Revision Manager")
         new RevisionManagerSnapshotImpl()
     }
 

--- a/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerClonedImpl.groovy
+++ b/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerClonedImpl.groovy
@@ -1,13 +1,11 @@
 package com.apgsga.revision.manager.domain
 
-import com.apgsga.revision.manager.persistence.RevisionPersistence
-
 class RevisionManagerClonedImpl implements RevisionManager{
 
-    private RevisionPersistence revisionPersistence
+    private RevisionManager delegate
 
-    RevisionManagerClonedImpl(RevisionPersistence revisionPersistence) {
-        this.revisionPersistence = revisionPersistence
+    RevisionManagerClonedImpl(RevisionManager delegate) {
+        this.delegate = delegate
     }
 
     @Override
@@ -17,13 +15,7 @@ class RevisionManagerClonedImpl implements RevisionManager{
 
     @Override
     String lastRevision(String serviceName, String target) {
-        assert target != null , "Target must be set, cannot be null"
-        String lastRevision = revisionPersistence.lastRevision(serviceName,target.toUpperCase())
-        if(lastRevision != null)
-            return lastRevision
-        else {
-            return "SNAPSHOT"
-        }
+       delegate.lastRevision(serviceName,target)
     }
 
     @Override

--- a/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerPatchImpl.groovy
+++ b/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerPatchImpl.groovy
@@ -1,8 +1,12 @@
 package com.apgsga.revision.manager.domain
 
 import com.apgsga.revision.manager.persistence.RevisionPersistence
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 class RevisionManagerPatchImpl implements RevisionManager {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(RevisionManagerPatchImpl.class)
 
     private RevisionPersistence revisionPersistence
 
@@ -14,6 +18,7 @@ class RevisionManagerPatchImpl implements RevisionManager {
     String nextRevision() {
         def currentRev  =revisionPersistence.currentRevision() as Integer
         currentRev++
+        LOGGER.info("RevisionManagerPatchImpl: returning nextRevision: ${currentRev}")
         return currentRev
     }
 
@@ -21,9 +26,12 @@ class RevisionManagerPatchImpl implements RevisionManager {
     String lastRevision(String serviceName, String target) {
         assert target != null , "Target must be set, cannot be null"
         String lastRevision = revisionPersistence.lastRevision(serviceName,target.toUpperCase())
-        if(lastRevision != null)
+        if(lastRevision != null) {
+            LOGGER.info("RevisionManagerPatchImpl: returning lastRevision: ${lastRevision}")
             return lastRevision
+        }
         else {
+            LOGGER.info("RevisionManagerPatchImpl: returning lastRevision: SNAPSHOT, because lastRevision is null")
             return "SNAPSHOT"
         }
     }

--- a/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerSnapshotImpl.groovy
+++ b/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerSnapshotImpl.groovy
@@ -1,18 +1,26 @@
 package com.apgsga.revision.manager.domain
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 class RevisionManagerSnapshotImpl implements RevisionManager {
 
+    private static Logger LOGGER = LoggerFactory.getLogger(RevisionManagerBuilder.class)
+
+
     @Override
     String nextRevision() {
+        LOGGER.info("RevisionManagerSnapshotImpl: Returning nextRevision: SNAPSHOT")
        "SNAPSHOT"
     }
 
     @Override
     String lastRevision(String serviceName, String target) {
+        LOGGER.info("RevisionManagerSnapshotImpl: Last Revision for ${serviceName} and ${target}: SNAPSHOT")
         "SNAPSHOT"
     }
 
     @Override
     void saveRevision(String serviceName, String target, String revision, String fullRevisionPrefix) {
+        LOGGER.info("RevisionManagerSnapshotImpl: Doing nothing on saveRevision for ${serviceName} and ${target}")
     }
 }

--- a/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/persistence/RevisionBeanBackedPersistence.groovy
+++ b/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/persistence/RevisionBeanBackedPersistence.groovy
@@ -1,8 +1,12 @@
 package com.apgsga.revision.manager.persistence
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 class RevisionBeanBackedPersistence implements RevisionPersistence {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(RevisionBeanBackedPersistence.class)
 
     File revisionRootDir
 
@@ -15,18 +19,17 @@ class RevisionBeanBackedPersistence implements RevisionPersistence {
     @Override
     String currentRevision() {
         def cr = read(Revisions.class).currentRevision
-        println "Current Revision: ${cr}"
+        println "RevisionBeanBackedPersistence : current Revision: ${cr}"
         return cr
     }
 
     @Override
     String lastRevision(String serviceName, String targetName) {
-        println "Getting lastRevision for service: ${serviceName} and ${targetName}"
+        LOGGER.info "RevisionBeanBackedPersistence: getting lastRevision for service: ${serviceName} and ${targetName}"
         def revisions = read(Revisions.class)
-        println "Current Revisions:  ${revisions.toString()} "
         if(revisions.services.get(serviceName) != null) {
             def lr = revisions.services.get(serviceName).get(targetName)
-            println "Got lastRevision: ${lr} for service: ${serviceName} and ${targetName}"
+            LOGGER.info "RevisionBeanBackedPersistence: got lastRevision: ${lr} for service: ${serviceName} and ${targetName}"
             return lr
         }
         return null
@@ -79,7 +82,7 @@ class RevisionBeanBackedPersistence implements RevisionPersistence {
         file.exists()
     }
 
-    private write(Object value, File rootDir) {
+    private static write(Object value, File rootDir) {
         String fileName = "${value.class.simpleName}.json"
         File file = new File(rootDir as File, fileName)
         ObjectMapper mapper = new ObjectMapper()
@@ -95,4 +98,12 @@ class RevisionBeanBackedPersistence implements RevisionPersistence {
         def obj = clx.newInstance(constArgs)
         write(obj)
     }
+
+    @Override
+    String toString() {
+        return "RevisionBeanBackedPersistence{" +
+                ", revisionRootDir=" + revisionRootDir +
+                '}'
+    }
+
 }

--- a/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/persistence/Revisions.groovy
+++ b/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/persistence/Revisions.groovy
@@ -15,4 +15,5 @@ class Revisions  {
     def lastRevision(String serviceName, String target, String revision) {
         services[serviceName][target] = revision
     }
+
 }


### PR DESCRIPTION
See IT-36103
Introduced slf4j-api based logging for revision-manager and added some info logging. 

The Plugin Versions have been bumped to 2.18-SNAPSHOT
