### PR TITLE
IT-36715 / Need to track revision ready to be assembled

### DIFF
--- a/plugins/gradle.properties
+++ b/plugins/gradle.properties
@@ -1,2 +1,2 @@
-publishVersion=2.19-SNAPSHOT
+publishVersion=2.20-SNAPSHOT
 publishGroup=com.apgsga.gradle

--- a/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerPatchImpl.groovy
+++ b/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerPatchImpl.groovy
@@ -16,8 +16,9 @@ class RevisionManagerPatchImpl implements RevisionManager {
 
     @Override
     String nextRevision() {
-        def currentRev  =revisionPersistence.currentRevision() as Integer
+        def currentRev  = revisionPersistence.currentRevision() as Integer
         currentRev++
+        revisionPersistence.save(currentRev as String)
         LOGGER.info("RevisionManagerPatchImpl: returning nextRevision: ${currentRev}")
         return currentRev
     }
@@ -38,7 +39,6 @@ class RevisionManagerPatchImpl implements RevisionManager {
 
     @Override
     void saveRevision(String serviceName, String target, String revision, String fullRevisionPrefix) {
-        revisionPersistence.save(revision as String)
         revisionPersistence.save(serviceName,target.toUpperCase(), revision.toUpperCase(), fullRevisionPrefix.toUpperCase())
     }
 

--- a/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
+++ b/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/ext/VersionResolution.kt
@@ -50,7 +50,7 @@ open class VersionResolutionExtension(val project: Project, private val revision
 
     // Revision Manager and Revision Initialization
     private var _revisionManger: RevisionManager? = null
-    private val revisionManger: RevisionManager
+    val revisionManger: RevisionManager
         get() {
             if (_revisionManger == null) {
                 _revisionManger = revisionManagerBuilder.revisionRootPath(revisionRootPath

--- a/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/plugin/MergeRevision.kt
+++ b/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/plugin/MergeRevision.kt
@@ -1,0 +1,18 @@
+package com.apgsga.maven.dm.plugin
+
+import com.apgsga.maven.dm.ext.VersionResolutionExtension
+import com.apgsga.revision.manager.domain.RevisionManagerBuilder
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+open class MergeRevision : DefaultTask() {
+
+    @TaskAction
+    fun merge() {
+        val ext = project.extensions.findByName("apgVersionResolver") as VersionResolutionExtension
+        val lastRev = ext.revisionManger.lastRevision(ext.serviceName,ext.installTarget)
+        project.logger.info("Revision " + lastRev + " will be merged into main Revisions.json for service " + ext.serviceName + " and target " + ext.installTarget)
+        val rm = RevisionManagerBuilder.create().revisionRootPath(project.gradle.gradleUserHomeDir.absolutePath).build();
+        rm.saveRevision(ext.serviceName,ext.installTarget,lastRev,ext.bomBaseVersion)
+    }
+}

--- a/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/plugin/VersionResolutionPlugin.kt
+++ b/plugins/version-manager/src/main/kotlin/com/apgsga/maven/dm/plugin/VersionResolutionPlugin.kt
@@ -22,10 +22,12 @@ open class VersionResolutionPlugin : Plugin<Project> {
             project,
             revisionManagerBuilder
         )
+
+        project.tasks.create("mergeRevision",MergeRevision::class.java)
+
         project.afterEvaluate {
             applyRecommendations(project, extension)
         }
-
     }
 
     private fun applyRecommendations(project: Project, resolutionExtension: VersionResolutionExtension) {


### PR DESCRIPTION
Basically a new revisionManager has been introduced in order to deal with revision being temporarily in a different place. 
We also save the revision differently. A new revision will be saved into the main Reivsions.json via the mergeRevision task. 