### PR TITLE
IT-35965 / Clone Pipeline

### DIFF
--- a/plugins/gradle.properties
+++ b/plugins/gradle.properties
@@ -1,2 +1,2 @@
-publishVersion=2.20-SNAPSHOT
+publishVersion=2.21-SNAPSHOT
 publishGroup=com.apgsga.gradle

--- a/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManager.groovy
+++ b/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManager.groovy
@@ -23,4 +23,11 @@ interface RevisionManager {
      */
     String nextRevision()
 
+    /**
+     * In context of a clone, we need the possibility to reset the last revision of a service for a given target
+     * @param serviceName
+     * @param target
+     * @param revision
+     */
+    void resetLastRevision(String serviceName, String target, String revision)
 }

--- a/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerClonedImpl.groovy
+++ b/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerClonedImpl.groovy
@@ -22,4 +22,9 @@ class RevisionManagerClonedImpl implements RevisionManager{
     String nextRevision() {
         throw new RuntimeException("nextRevision not supported by ${RevisionManagerClonedImpl.class.name}")
     }
+
+    @Override
+    void resetLastRevision(String serviceName, String target, String revision) {
+        throw new RuntimeException("resetLastRevision not supported by ${RevisionManagerClonedImpl.class.name}")
+    }
 }

--- a/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerPatchImpl.groovy
+++ b/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerPatchImpl.groovy
@@ -24,6 +24,11 @@ class RevisionManagerPatchImpl implements RevisionManager {
     }
 
     @Override
+    void resetLastRevision(String serviceName, String target, String revision) {
+        revisionPersistence.resetLastRevision(serviceName,target.toUpperCase(),revision.toUpperCase())
+    }
+
+    @Override
     String lastRevision(String serviceName, String target) {
         assert target != null , "Target must be set, cannot be null"
         String lastRevision = revisionPersistence.lastRevision(serviceName,target.toUpperCase())

--- a/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerSnapshotImpl.groovy
+++ b/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/domain/RevisionManagerSnapshotImpl.groovy
@@ -14,6 +14,11 @@ class RevisionManagerSnapshotImpl implements RevisionManager {
     }
 
     @Override
+    void resetLastRevision(String serviceName, String target, String revision) {
+        LOGGER.info("RevisionManagerSnapshotImpl: Doing nothing on resetLastRevision.")
+    }
+
+    @Override
     String lastRevision(String serviceName, String target) {
         LOGGER.info("RevisionManagerSnapshotImpl: Last Revision for ${serviceName} and ${target}: SNAPSHOT")
         "SNAPSHOT"

--- a/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/persistence/RevisionBeanBackedPersistence.groovy
+++ b/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/persistence/RevisionBeanBackedPersistence.groovy
@@ -54,6 +54,11 @@ class RevisionBeanBackedPersistence implements RevisionPersistence {
         write(revisions,new File(targetFolderPath))
     }
 
+    @Override
+    void resetLastRevision(String serviceName, String target, String revision) {
+        saveRevision(serviceName,target,revision)
+    }
+
     private void saveRevisionHistory(String serviceName, String target, String versionPrefix, String revision) {
         def targetsHistory = read(RevisionTargetHistory.class)
         targetsHistory.add(serviceName,target,versionPrefix,revision)

--- a/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/persistence/RevisionPersistence.groovy
+++ b/plugins/revision-manager/src/main/groovy/com/apgsga/revision/manager/persistence/RevisionPersistence.groovy
@@ -31,4 +31,12 @@ interface RevisionPersistence {
      */
     void cloneRevisionsJson(String targetFolderPath)
 
+    /**
+     * In context of a clone, we need the possibility to reset the last revision of a service for a given target
+     * @param serviceName
+     * @param target
+     * @param revision
+     */
+    void resetLastRevision(String serviceName, String target, String revision)
+
 }

--- a/plugins/revision-manager/src/test/groovy/com/apgsga/revision/manager/domain/RevisionManagerLocalPersistenceTests.groovy
+++ b/plugins/revision-manager/src/test/groovy/com/apgsga/revision/manager/domain/RevisionManagerLocalPersistenceTests.groovy
@@ -131,4 +131,14 @@ class RevisionManagerLocalPersistenceTests extends Specification {
             Files.exists(Paths.get(historyFilePath))
             Files.exists(Paths.get(revisionClonedFilePath))
     }
+
+    def "Reset last revision for a target"() {
+        when:
+            revisionManagerPatch.saveRevision("testService_1","chei212","10","TEST-")
+            revisionManagerPatch.saveRevision("testService_1","chei211","15","TEST-")
+            revisionManagerPatch.resetLastRevision("testService_1","chei212","22")
+        then:
+            "22".equals(revisionManagerPatch.lastRevision("testService_1","chei212"))
+            "15".equals(revisionManagerPatch.lastRevision("testService_1","chei211"))
+    }
 }


### PR DESCRIPTION
In context of the clone pipeline, we need the possibility to reset a revision for a service on a particular target. A new method has been define on the interface in order not to directly update the Revisions.json from the pipeline.